### PR TITLE
Can't verify rsync source against client mounts because it might refe…

### DIFF
--- a/controllers/datamovement_controller_lustre.go
+++ b/controllers/datamovement_controller_lustre.go
@@ -394,7 +394,7 @@ func (r *DataMovementReconciler) createMpiJob(ctx context.Context, dm *nnfv1alph
 	}
 
 	command = append(command, "dcp", sourcePath, destinationPath)
-	
+
 	if cmd, found := config.Data[configCommand]; found {
 		if strings.HasPrefix(cmd, "/bin/bash -c") {
 			command = []string{"/bin/bash", "-c", strings.TrimPrefix(cmd, "/bin/bash -c")}

--- a/controllers/rsyncnodedatamovement_controller.go
+++ b/controllers/rsyncnodedatamovement_controller.go
@@ -106,18 +106,6 @@ func (r *RsyncNodeDataMovementReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	if err := r.verifySourcePath(ctx, rsyncNode); err != nil {
-		rsyncNode.Status.EndTime = metav1.Now()
-		rsyncNode.Status.State = nnfv1alpha1.DataMovementConditionTypeFinished
-		rsyncNode.Status.Status = nnfv1alpha1.DataMovementConditionReasonInvalid
-		rsyncNode.Status.Message = err.Error()
-		if err := r.Status().Update(ctx, rsyncNode); err != nil {
-			log.Error(err, "failed to set rsync node as invalid")
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
 	arguments := []string{}
 	if rsyncNode.Spec.DryRun {
 		arguments = append(arguments, "--dry-run")

--- a/controllers/rsyncnodedatamovement_controller.go
+++ b/controllers/rsyncnodedatamovement_controller.go
@@ -21,10 +21,8 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -35,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	dmv1alpha1 "github.com/NearNodeFlash/nnf-dm/api/v1alpha1"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
@@ -160,31 +157,6 @@ func (r *RsyncNodeDataMovementReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *RsyncNodeDataMovementReconciler) verifySourcePath(ctx context.Context, rsyncNode *dmv1alpha1.RsyncNodeDataMovement) error {
-	listOptions := []client.ListOption{
-		client.InNamespace(rsyncNode.GetNamespace()),
-		client.MatchingLabels(map[string]string{
-			dwsv1alpha1.WorkflowNameLabel: rsyncNode.Labels[dmv1alpha1.OwnerLabelRsyncNodeDataMovement],
-			dwsv1alpha1.WorkflowNamespaceLabel: rsyncNode.Labels[dmv1alpha1.OwnerNamespaceLabelRsyncNodeDataMovement],
-		}),
-	}
-
-	clientMounts := &dwsv1alpha1.ClientMountList{}
-	if err := r.List(ctx, clientMounts, listOptions...); err != nil {
-		return err
-	}
-
-	for _, clientMount := range clientMounts.Items {
-		for _, mount := range clientMount.Spec.Mounts {
-			if strings.HasPrefix(rsyncNode.Spec.Source, mount.MountPath) {
-				return nil
-			}
-		}
-	}
-
-	return fmt.Errorf("Source path '%s' not found in list of client mounts", rsyncNode.Spec.Source)
 }
 
 func (r *RsyncNodeDataMovementReconciler) recordCompletion(rsyncNode dmv1alpha1.RsyncNodeDataMovement) {

--- a/controllers/rsyncnodedatamovement_controller_test.go
+++ b/controllers/rsyncnodedatamovement_controller_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Rsync Node Data Movement Controller", func() {
 		Expect(os.RemoveAll("directory.out")).To(Succeed())
 	})
 
-	PDescribeTable("Test various copy operations", func(source string, destination string, file bool) {
+	DescribeTable("Test various copy operations", func(source string, destination string, file bool) {
 		rsync.Spec.Source = source
 		rsync.Spec.Destination = destination
 

--- a/daemons/compute/client-go/main.go
+++ b/daemons/compute/client-go/main.go
@@ -33,7 +33,6 @@ import (
 
 func main() {
 
-
 	workflow := flag.String("workflow", os.Getenv("DW_WORKFLOW_NAME"), "parent workflow name")
 	namespace := flag.String("namespace", os.Getenv("DW_WORKFLOW_NAMESPACE"), "parent workflow namespace")
 	source := flag.String("source", "", "source file or directory")


### PR DESCRIPTION
Can't verify rsync source against client mounts because it might refer to a global lustre fs

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>