### PR TITLE
RABSW-983 Re-enable the nnf-dm tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 FAILFAST ?= no
-test: #manifests generate fmt vet envtest ## Run tests.
+test: manifests generate fmt vet envtest ## Run tests.
 	if [[ "${FAILFAST}" == yes ]]; then \
 		failfast="-ginkgo.failFast"; \
 	fi; \


### PR DESCRIPTION
Re-enable test dependencies

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>