### PR TITLE
Initialize the defaultServer.completions map.

### DIFF
--- a/daemons/compute/server/servers/server_default.go
+++ b/daemons/compute/server/servers/server_default.go
@@ -132,11 +132,12 @@ func CreateDefaultServer(opts *ServerOptions) (*defaultServer, error) {
 	}
 
 	return &defaultServer{
-		config:    config,
-		client:    client,
-		name:      opts.name,
-		namespace: opts.nodeName,
-		cond:      sync.NewCond(&sync.Mutex{}),
+		config:      config,
+		client:      client,
+		name:        opts.name,
+		namespace:   opts.nodeName,
+		cond:        sync.NewCond(&sync.Mutex{}),
+		completions: make(map[string]struct{}),
 	}, nil
 }
 


### PR DESCRIPTION
Fix a panic due to "assignment to entry in nil map" in notifyCompletion().

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>