### PR TITLE
RABSW-1004 Add metrics support to the operators

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,0 +1,20 @@
+
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -39,6 +39,7 @@ import (
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
 	dmv1alpha1 "github.com/NearNodeFlash/nnf-dm/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-dm/controllers/metrics"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	mpiv2beta1 "github.com/kubeflow/mpi-operator/v2/pkg/apis/kubeflow/v2beta1"
 )
@@ -80,6 +81,8 @@ type DataMovementReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+
+	metrics.NnfDmDataMovementReconcilesTotal.Inc()
 
 	dm := &nnfv1alpha1.NnfDataMovement{}
 	if err := r.Get(ctx, req.NamespacedName, dm); err != nil {

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	NnfDmDataMovementReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnfdm_datamovement_reconciles_total",
+			Help: "Number of total reconciles in nnfdm datamovement controller",
+		},
+	)
+
+	NnfDmRsyncNodeDataMovementReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnfdm_rsyncnode_datamovement_reconciles_total",
+			Help: "Number of total reconciles in nnfdm rsyncnode_datamovement controller",
+		},
+	)
+
+	NnfDmRsyncTemplateReconcilesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nnfdm_rsynctemplate_reconciles_total",
+			Help: "Number of total reconciles in nnfdm rsynctemplate controller",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(NnfDmDataMovementReconcilesTotal)
+	metrics.Registry.MustRegister(NnfDmRsyncNodeDataMovementReconcilesTotal)
+	metrics.Registry.MustRegister(NnfDmRsyncTemplateReconcilesTotal)
+}

--- a/controllers/rsyncnodedatamovement_controller.go
+++ b/controllers/rsyncnodedatamovement_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	dmv1alpha1 "github.com/NearNodeFlash/nnf-dm/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-dm/controllers/metrics"
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 )
 
@@ -62,6 +63,8 @@ type RsyncNodeDataMovementReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *RsyncNodeDataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+
+	metrics.NnfDmRsyncNodeDataMovementReconcilesTotal.Inc()
 
 	rsyncNode := &dmv1alpha1.RsyncNodeDataMovement{}
 	if err := r.Get(ctx, req.NamespacedName, rsyncNode); err != nil {

--- a/controllers/rsynctemplate_controller.go
+++ b/controllers/rsynctemplate_controller.go
@@ -39,6 +39,7 @@ import (
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
 
 	dmv1alpha1 "github.com/NearNodeFlash/nnf-dm/api/v1alpha1"
+	"github.com/NearNodeFlash/nnf-dm/controllers/metrics"
 )
 
 const (
@@ -71,6 +72,8 @@ type RsyncTemplateReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *RsyncTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+
+	metrics.NnfDmRsyncTemplateReconcilesTotal.Inc()
 
 	rsyncTemplate := &dmv1alpha1.RsyncTemplate{}
 	if err := r.Get(ctx, req.NamespacedName, rsyncTemplate); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/kubeflow/mpi-operator/v2 v2.0.0-20211209024655-d7fc50603a4d
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/takama/daemon v1.0.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,6 +149,7 @@ github.com/onsi/gomega/types
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
Add some basic seed metrics to the operators,  to act as a pattern for others
to follow.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>