### PR TITLE
Add tests for Data Movement Controller

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,6 +61,24 @@
             "request": "launch",
             "cwd": "${workspaceFolder}",
             "program": "${workspaceRoot}/daemons/compute/lib-cpp/example/cmake/build/client",
-        }
+        },
+        {
+            "name": "Test Current File",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/controllers",
+            "args": [
+                "-ginkgo.v",
+                "-ginkgo.progress",
+                "-ginkgo.failFast",
+            ],
+            "env": {
+                "KUBEBUILDER_ASSETS": "${workspaceRoot}/bin/k8s/1.25.0-darwin-amd64",
+                "GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT": "10m",
+                "GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL": "500ms",
+            },
+            "showLog": true
+        },
     ]
 }

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -201,16 +201,20 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Execute the go routine to perform the data movement
 	go func() {
+		var cmd *exec.Cmd
 
 		// TODO: UserId/GroupId
 
-		cmd := exec.CommandContext(ctxCancel,
-			"mpirun",
-			"--allow-run-as-root",
-			"-np", fmt.Sprintf("%d", len(hosts)), // # TODO: Might want to adjust this if running on a rabbit node
-			"--host", strings.Join(hosts, ","),
-			"dcp", dm.Spec.Source.Path, dm.Spec.Destination.Path)
-
+		if isTestEnv() {
+			cmd = exec.CommandContext(ctxCancel, "sleep", "1")
+		} else {
+			cmd = exec.CommandContext(ctxCancel,
+				"mpirun",
+				"--allow-run-as-root",
+				"-np", fmt.Sprintf("%d", len(hosts)), // # TODO: Might want to adjust this if running on a rabbit node
+				"--host", strings.Join(hosts, ","),
+				"dcp", dm.Spec.Source.Path, dm.Spec.Destination.Path)
+		}
 		log.Info("Running Command", "cmd", cmd.String())
 
 		// TODO: Capture output as it progresses and add a %complete to the resource
@@ -228,7 +232,7 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		} else if err != nil {
 			log.Error(err, "Data movement operation failed", "output", string(out))
 			dm.Status.Status = nnfv1alpha1.DataMovementConditionReasonFailed
-			dm.Status.Message = err.Error()
+			dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), string(out))
 
 			// TODO: Enhanced error capture: parse error response and provide useful message
 		} else {
@@ -296,11 +300,18 @@ func (r *DataMovementReconciler) cancel(ctx context.Context, dm *nnfv1alpha1.Nnf
 	return nil
 }
 
+func isTestEnv() bool {
+	if testEnv, found := os.LookupEnv("NNF_TEST_ENVIRONMENT"); found && strings.ToLower(testEnv) == "true" {
+		return true
+	} else {
+		return false
+	}
+}
+
 // Retrieve the NNF Nodes that are the target of the data movement operation
 func (r *DataMovementReconciler) getStorageNodeNames(ctx context.Context, dm *nnfv1alpha1.NnfDataMovement) ([]string, error) {
-
 	// If this is a node data movement request simply reference the localhost
-	if dm.Namespace == os.Getenv("NNF_NODE_NAME") {
+	if dm.Namespace == os.Getenv("NNF_NODE_NAME") || isTestEnv() {
 		return []string{"localhost"}, nil
 	}
 

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -301,11 +301,8 @@ func (r *DataMovementReconciler) cancel(ctx context.Context, dm *nnfv1alpha1.Nnf
 }
 
 func isTestEnv() bool {
-	if testEnv, found := os.LookupEnv("NNF_TEST_ENVIRONMENT"); found && strings.ToLower(testEnv) == "true" {
-		return true
-	} else {
-		return false
-	}
+	_, found := os.LookupEnv("NNF_TEST_ENVIRONMENT")
+	return found
 }
 
 // Retrieve the NNF Nodes that are the target of the data movement operation

--- a/controllers/datamovement_controller_test.go
+++ b/controllers/datamovement_controller_test.go
@@ -26,6 +26,7 @@ import (
 	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,33 +83,34 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 
 	Context("when a data movement operation succeeds", func() {
 		It("should have a state and status of 'Finished' and 'Success'", func() {
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega) nnfv1alpha1.NnfDataMovementStatus {
 				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
-				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeFinished))
-				g.Expect(dm.Status.Status).To(Equal(nnfv1alpha1.DataMovementConditionReasonSuccess))
-			}, dmTestTimeout).Should(Succeed())
+				return dm.Status
+			}, dmTestTimeout).Should(MatchFields(IgnoreExtras, Fields{
+				"State":  Equal(nnfv1alpha1.DataMovementConditionTypeFinished),
+				"Status": Equal(nnfv1alpha1.DataMovementConditionReasonSuccess),
+			}))
 		})
 	})
 
 	Context("when a data movement operation is cancelled", func() {
 		It("should have a state and status of 'Finished' and 'Cancelled'", func() {
 			By("ensuring the data movement started")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega) string {
 				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
-				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeRunning))
-			}, dmTestTimeout).Should(Succeed())
+				return dm.Status.State
+			}, dmTestTimeout).Should(Equal(nnfv1alpha1.DataMovementConditionTypeRunning))
 
 			By("setting the cancel flag to true")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega) error {
 				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
 				dm.Spec.Cancel = true
-				g.Expect(k8sClient.Update(context.TODO(), dm)).To(Succeed())
+				return k8sClient.Update(context.TODO(), dm)
 			}, dmTestTimeout).Should(Succeed())
 
 			By("verifying that it was cancelled successfully")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
-				g.Expect(dm.Spec.Cancel).To(Equal(true))
 				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeFinished))
 				g.Expect(dm.Status.Status).To(Equal(nnfv1alpha1.DataMovementConditionReasonCancelled))
 			}, dmTestTimeout).Should(Succeed())

--- a/controllers/datamovement_controller_test.go
+++ b/controllers/datamovement_controller_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import (
+	"context"
+	"os"
+
+	nnfv1alpha1 "github.com/NearNodeFlash/nnf-sos/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
+	var dm *nnfv1alpha1.NnfDataMovement = nil
+	var srcPath, destPath string
+	var err error
+
+	// test is using `sleep 1` for datamovement, so add some padding
+	dmTestTimeout := 3
+
+	BeforeEach(func() {
+		srcPath, err = os.MkdirTemp("/tmp", "dm-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		destPath, err = os.MkdirTemp("/tmp", "dm-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		dm = &nnfv1alpha1.NnfDataMovement{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dm-test",
+				Namespace: corev1.NamespaceDefault,
+			},
+			Spec: nnfv1alpha1.NnfDataMovementSpec{
+				Source: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
+					Path: srcPath,
+				},
+				Destination: &nnfv1alpha1.NnfDataMovementSpecSourceDestination{
+					Path: destPath,
+				},
+				UserId:  uint32(os.Geteuid()),
+				GroupId: uint32(os.Getegid()),
+				Cancel:  false,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(context.TODO(), dm)).To(Succeed())
+	})
+
+	JustAfterEach(func() {
+		Expect(k8sClient.Delete(context.TODO(), dm)).To(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)
+		}).ShouldNot(Succeed())
+		Expect(os.Remove(srcPath)).To(Succeed())
+		Expect(os.Remove(destPath)).To(Succeed())
+
+	})
+
+	Context("when a data movement operation succeeds", func() {
+		It("should have a state and status of 'Finished' and 'Success'", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
+				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeFinished))
+				g.Expect(dm.Status.Status).To(Equal(nnfv1alpha1.DataMovementConditionReasonSuccess))
+			}, dmTestTimeout).Should(Succeed())
+		})
+	})
+
+	Context("when a data movement operation is cancelled", func() {
+		It("should have a state and status of 'Finished' and 'Cancelled'", func() {
+			By("ensuring the data movement started")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
+				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeRunning))
+			}, dmTestTimeout).Should(Succeed())
+
+			By("setting the cancel flag to true")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
+				dm.Spec.Cancel = true
+				g.Expect(k8sClient.Update(context.TODO(), dm)).To(Succeed())
+			}, dmTestTimeout).Should(Succeed())
+
+			By("verifying that it was cancelled successfully")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
+				g.Expect(dm.Spec.Cancel).To(Equal(true))
+				g.Expect(dm.Status.State).To(Equal(nnfv1alpha1.DataMovementConditionTypeFinished))
+				g.Expect(dm.Status.Status).To(Equal(nnfv1alpha1.DataMovementConditionReasonCancelled))
+			}, dmTestTimeout).Should(Succeed())
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -57,10 +57,25 @@ var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 
+type envSetting struct {
+	envVar string
+	value  string
+}
+
+var envVars = []envSetting{
+	{"ACK_GINKGO_DEPRECATIONS", "1.16.5"},
+
+	// Enable certain quirks necessary for test
+	{"NNF_TEST_ENVIRONMENT", "true"},
+}
+
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	os.Setenv("ACK_GINKGO_DEPRECATIONS", "1.16.5")
+	// Setup environment variables for the test
+	for _, v := range envVars {
+		os.Setenv(v.envVar, v.value)
+	}
 
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Controller Suite",


### PR DESCRIPTION
This adds two test cases:
1. Verify data movement
2. Verify data movement cancellation

Since data movement relies on mpifileutils and other dependencies, these tests rely on setting the `NNF_TEST_ENVIRONMENT` environment variable to use `sleep` instead. It also short circuits `getStorageNodeNames` and returns a list of just the localhost. This then using the existing short circuit in `getWorkerHostnames`.