### PR TITLE
RABSW-1012: Package nnf-dm daemon as an RPM

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -1,0 +1,37 @@
+name: RPM Build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:8
+      env:
+        NODE_ENV: development
+      ports:
+        - 80
+      options: --cpus 1
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: environment setup
+        run: |
+          dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos
+          dnf -y distro-sync
+          dnf -y makecache --refresh
+          dnf install -y rpm-build rpmdevtools git make
+          dnf module -y install go-toolset 
+          rpmdev-setuptree
+          tar -czf /github/home/rpmbuild/SOURCES/nnf-datamovement-1.0.tar.gz --transform 's,^,nnf-datamovement-1.0/,' .
+      - name: build rpms
+        run: rpmbuild -ba daemons/compute/server/nnf-dm.spec
+      - name: upload rpms
+        uses: actions/upload-artifact@v3
+        with:
+          name: nnf-datamovement-1.0-1.el8.x86_64.rpm
+          path: /github/home/rpmbuild/RPMS/x86_64/nnf-datamovement-1.0-1.el8.x86_64.rpm
+      - name: upload srpms
+        uses: actions/upload-artifact@v3
+        with:
+          name: nnf-datamovement-1.0-1.el8.src.rpm
+          path: /github/home/rpmbuild/SRPMS/nnf-datamovement-1.0-1.el8.src.rpm

--- a/daemons/compute/server/nnf-dm.spec
+++ b/daemons/compute/server/nnf-dm.spec
@@ -1,0 +1,31 @@
+%undefine _missing_build_ids_terminate_build
+%global debug_package %{nil}
+
+Name: nnf-datamovement
+Version: 1.0
+Release: 1%{?dist}
+Summary: Near Node Flash data movement daemon
+
+Group: 1
+License: Apache-2.0
+URL: https://github.com/NearNodeFlash/nnf-dm
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires:	golang
+
+%description
+This package provides the data movement server for Near Node Flash. This allows
+Near Node Flash data movement through the data movement API.
+
+%prep
+%setup -q
+
+%build
+GOOS=linux GOARCH=amd64 go build -o bin/nnf-dm
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+install -m 755 bin/nnf-dm %{buildroot}/usr/bin/nnf-dm
+
+%files
+/usr/bin/nnf-dm


### PR DESCRIPTION
This commit adds a spec file and a github action to package the nnf-dm as an RPM. Both binary and source RPMs are generated.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>