### PR TITLE
Remove nnf-dm specific prefix from service arguments; this will permi…

### DIFF
--- a/daemons/compute/server/servers/server.go
+++ b/daemons/compute/server/servers/server.go
@@ -52,8 +52,8 @@ func GetOptions() (*ServerOptions, error) {
 	flag.StringVar(&opts.port, "kubernetes-service-port", opts.port, "Kubernetes service port number")
 	flag.StringVar(&opts.name, "node-name", opts.name, "Name of this compute resource")
 	flag.StringVar(&opts.nodeName, "nnf-node-name", opts.nodeName, "NNF node name that should handle the data movement request")
-	flag.StringVar(&opts.tokenFile, "nnf-data-movement-service-token-file", opts.tokenFile, "Path to the NNF data movement service token")
-	flag.StringVar(&opts.certFile, "nnf-data-movement-service-cert-file", opts.certFile, "Path to the NNF data movement service certificate")
+	flag.StringVar(&opts.tokenFile, "service-token-file", opts.tokenFile, "Path to the NNF data movement service token")
+	flag.StringVar(&opts.certFile, "service-cert-file", opts.certFile, "Path to the NNF data movement service certificate")
 	flag.BoolVar(&opts.simulated, "simulated", opts.simulated, "Run in simulation mode where no requests are sent to the server")
 	flag.Parse()
 	return &opts, nil


### PR DESCRIPTION
Remove nnf-dm specific prefix from service arguments; this will permit us to use more common variable names between daemons.

the companion change to dws is located here: https://github.com/HewlettPackard/dws/pull/63

nnf-deploy change planned for today after both are merged

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>