### PR TITLE
RABSW-1084: Allow non-root users to use nnf-dm socket on the compute node

### DIFF
--- a/daemons/compute/server/main.go
+++ b/daemons/compute/server/main.go
@@ -93,6 +93,11 @@ func (service *Service) Manage() (string, error) {
 		return fmt.Sprintf("Failed to listen at socket %s", *socketAddr), err
 	}
 
+	// Set socket permissions so non-root users can communicate
+	if err = os.Chmod(*socketAddr, 0766); err != nil {
+		return fmt.Sprintf("Failed to set permissions on socket %s", *socketAddr), err
+	}
+
 	go service.Run(server, listener)
 
 	for {


### PR DESCRIPTION

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>