### PR TITLE
Add permissions to data movement via dcp options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV CGO_ENABLED=0
 ENTRYPOINT [ "make", "test" ]
 
 ###############################################################################
-FROM ghcr.io/nearnodeflash/nnf-mfu:latest
+FROM ghcr.io/nearnodeflash/nnf-mfu:82aa3c4b6655433dacbe3294ad359161c62219c6
 
 RUN apt update
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: worker
-          image: ghcr.io/nearnodeflash/nnf-mfu:latest
+          image: ghcr.io/nearnodeflash/nnf-mfu:82aa3c4b6655433dacbe3294ad359161c62219c6
           command: 
             - /usr/sbin/sshd
           args:

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -423,11 +423,12 @@ func getCmdAndArgs(cmCommand string, cmNumProcesses int, progressInterval int, h
 
 		cmd = "mpirun"
 		args = []string{
-			"--allow-run-as-root", // TODO: UserId/GroupId
+			"--allow-run-as-root", // required to be able to set dcp uid/gid
 			"-np", fmt.Sprintf("%d", numProcesses),
 			"--host", strings.Join(hosts, ","),
 			"dcp",
 			"--progress", fmt.Sprintf("%d", progressInterval),
+			fmt.Sprintf("-U %d -G %d", dm.Spec.UserId, dm.Spec.GroupId),
 			dm.Spec.Source.Path, dm.Spec.Destination.Path,
 		}
 	}

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -428,7 +428,8 @@ func getCmdAndArgs(cmCommand string, cmNumProcesses int, progressInterval int, h
 			"--host", strings.Join(hosts, ","),
 			"dcp",
 			"--progress", fmt.Sprintf("%d", progressInterval),
-			fmt.Sprintf("-U %d -G %d", dm.Spec.UserId, dm.Spec.GroupId),
+			"--uid", fmt.Sprintf("%d", dm.Spec.UserId),
+			"--gid", fmt.Sprintf("%d", dm.Spec.GroupId),
 			dm.Spec.Source.Path, dm.Spec.Destination.Path,
 		}
 	}

--- a/controllers/datamovement_controller_test.go
+++ b/controllers/datamovement_controller_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 17 --host localhost dcp --progress 1 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 17 --host localhost dcp --progress 1 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 
 		AfterEach(func() {
@@ -230,7 +230,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 	})
 
@@ -249,7 +249,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 	})
 
@@ -306,7 +306,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 7 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 7 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 	})
 
@@ -325,7 +325,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 	})
 
@@ -344,7 +344,7 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U 0 -G 0 %s %s", srcPath, destPath)))
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 --uid 0 --gid 0 %s %s", srcPath, destPath)))
 		})
 	})
 
@@ -592,26 +592,8 @@ var _ = Describe("Data Movement Test" /*Ordered, (Ginkgo v2)*/, func() {
 				}
 				return cmd
 			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U %d -G %d %s %s",
+				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 --uid %d --gid %d %s %s",
 				expectedUid, expectedGid, srcPath, destPath)))
-		})
-	})
-
-	Context("when the data movement operation has uid and gid set to 0", func() {
-		BeforeEach(func() {
-			cm.Data[configMapKeyCmd] = ""
-		})
-		It("should have -U and -G in the data movement dcp command", func() {
-			Eventually(func(g Gomega) string {
-				cmd := ""
-				g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm)).To(Succeed())
-				if dm.Status.CommandStatus != nil {
-					cmd = dm.Status.CommandStatus.Command
-				}
-				return cmd
-			}).Should(Equal(fmt.Sprintf(
-				"mpirun --allow-run-as-root -np 1 --host localhost dcp --progress 1 -U %d -G %d %s %s",
-				0, 0, srcPath, destPath)))
 		})
 	})
 })


### PR DESCRIPTION
The nnf-mfu image update allows us to use the new (but not approved) dcp `-U` and `-G` options to set the user and group ID to perform the data movement.

Note that this change requires that the mount points for the src and dest of the data movement also has the proper permissions. That part of this is not yet implemented.