### PR TITLE
To support Kubernetes >= 1.24, manually create the SA Secret

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/config/rbac/kustomizeconfig.yaml
+++ b/config/rbac/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+namePrefix:
+- path: metadata/annotations/kubernetes.io\/service-account.name
+namespace:
+- path: metadata/annotations/kubernetes.io\/service-account.namespace

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,16 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+---
+# As of Kubernetes 1.24, ServiceAccount tokens are no longer automatically
+# generated. Instead, manually create the secret and the token key in the
+# data field will be automatically set.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: controller-manager
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token

--- a/deploy.sh
+++ b/deploy.sh
@@ -55,8 +55,8 @@ undeploy)
     # When the DataMovementManager CRD gets deleted all related resource are also
     # removed, so the delete will always fail. We ignore all errors at our
     # own risk.
-    $KUSTOMIZE build config/default | kubectl delete -f - || true
-    $KUSTOMIZE build config/dm_config | kubectl delete -f - || true
+    $KUSTOMIZE build config/default | kubectl delete --ignore-not-found -f -
+    $KUSTOMIZE build config/dm_config | kubectl delete --ignore-not-found -f -
     ;;
 *)
     usage


### PR DESCRIPTION
Kubernetes 1.24 enabled [LegacyServiceAccountTokenNoAutoGeneration](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2799-reduction-of-secret-based-service-account-token#legacyserviceaccounttokennoautogeneration). As such, we need to manually create the Secret. Annotations relate the Secret to the ServiceAccount.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>