### PR TITLE
Installation improvements to the nnf-dm daemon

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -130,6 +130,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - systemconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - nnf.cray.hpe.com
   resources:
   - nnfdatamovements

--- a/daemons/compute/server/servers/server.go
+++ b/daemons/compute/server/servers/server.go
@@ -34,6 +34,7 @@ type ServerOptions struct {
 
 	name      string
 	nodeName  string
+	sysConfig string
 	simulated bool
 }
 
@@ -54,6 +55,7 @@ func GetOptions() (*ServerOptions, error) {
 	flag.StringVar(&opts.nodeName, "nnf-node-name", opts.nodeName, "NNF node name that should handle the data movement request")
 	flag.StringVar(&opts.tokenFile, "service-token-file", opts.tokenFile, "Path to the NNF data movement service token")
 	flag.StringVar(&opts.certFile, "service-cert-file", opts.certFile, "Path to the NNF data movement service certificate")
+	flag.StringVar(&opts.sysConfig, "sys-config", "default", "Name of the system configuration containing this compute resource")
 	flag.BoolVar(&opts.simulated, "simulated", opts.simulated, "Run in simulation mode where no requests are sent to the server")
 	flag.Parse()
 	return &opts, nil

--- a/daemons/compute/server/servers/server_default.go
+++ b/daemons/compute/server/servers/server_default.go
@@ -183,7 +183,7 @@ func CreateDefaultServer(opts *ServerOptions) (*defaultServer, error) {
 		}
 
 		if storageNode.Type != "Rabbit" {
-			return nil, fmt.Errorf("storage node type '%s' not supported", storageNode.Type)
+			return nil, fmt.Errorf("storage node type '%s' not supported. Must be 'Rabbit'", storageNode.Type)
 		}
 
 		log.Println("Found Storage Node", storageNode.Name)

--- a/daemons/compute/server/servers/server_default.go
+++ b/daemons/compute/server/servers/server_default.go
@@ -182,7 +182,9 @@ func CreateDefaultServer(opts *ServerOptions) (*defaultServer, error) {
 			return nil, fmt.Errorf("storage node not found in system configuration")
 		}
 
-		// TODO: Should we check the storageNode.Type == "Rabbit" ???
+		if storageNode.Type != "Rabbit" {
+			return nil, fmt.Errorf("storage node type '%s' not supported", storageNode.Type)
+		}
 
 		log.Println("Found Storage Node", storageNode.Name)
 		opts.nodeName = storageNode.Name


### PR DESCRIPTION
- Use the os.Hostname() value in absence of a supplied `--node-name` argument.
- Use the SystemConfiguration{} to find the NNF Node Name in the absence of a supplied `--nnf-node-name` argument.
- Add an additional argument, `--sys-config`, to specify the SystemConfiguration name (if not "default").

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>