### PR TITLE
Added workflow to build nnf-dm lib-cpp 

### DIFF
--- a/.github/workflows/nnf_dm_lib.yml
+++ b/.github/workflows/nnf_dm_lib.yml
@@ -1,0 +1,14 @@
+name: NNF-DM Library Build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/nearnodeflash/grpc-cxx:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build nnf-dm lib-cpp
+        run: |
+          cd daemons/compute/lib-cpp
+          cmake -D CMAKE_INSTALL_PREFIX=/opt/grpc .
+          make

--- a/daemons/compute/lib-cpp/client.cc
+++ b/daemons/compute/lib-cpp/client.cc
@@ -215,11 +215,12 @@ StatusResponse::~StatusResponse() {
 }
 
 StatusResponse::State StatusResponse::state() {
-    CHECK_ENUM_EQUALITY(StatusResponse::STATE_PENDING,   datamovement::DataMovementStatusResponse_State_PENDING);
-    CHECK_ENUM_EQUALITY(StatusResponse::STATE_STARTING,  datamovement::DataMovementStatusResponse_State_STARTING);
-    CHECK_ENUM_EQUALITY(StatusResponse::STATE_RUNNING,   datamovement::DataMovementStatusResponse_State_RUNNING);
-    CHECK_ENUM_EQUALITY(StatusResponse::STATE_COMPLETED, datamovement::DataMovementStatusResponse_State_COMPLETED);
-    CHECK_ENUM_EQUALITY(StatusResponse::STATE_UNKNOWN,   datamovement::DataMovementStatusResponse_State_UNKNOWN_STATE);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_PENDING,    datamovement::DataMovementStatusResponse_State_PENDING);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_STARTING,   datamovement::DataMovementStatusResponse_State_STARTING);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_RUNNING,    datamovement::DataMovementStatusResponse_State_RUNNING);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_COMPLETED,  datamovement::DataMovementStatusResponse_State_COMPLETED);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_CANCELLING, datamovement::DataMovementStatusResponse_State_CANCELLING);
+    CHECK_ENUM_EQUALITY(StatusResponse::STATE_UNKNOWN,    datamovement::DataMovementStatusResponse_State_UNKNOWN_STATE);
 
     auto state = static_cast<datamovement::DataMovementStatusResponse *>(data_)->state();
     return static_cast<StatusResponse::State>(state);


### PR DESCRIPTION
Use github.com/NearNodeFlash/grpc-cxx image to build the data movement
c++ library to ensure that we have not broken it.

The use of the grpc-cxx container significantly cuts down on build time
since our c++ lib is simple.