### PR TITLE
Build the correct binary for RPM packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ container-unit-test: ## Run tests inside a container image
 	$(DOCKER) run --rm -t --name $@-nnf-dm  $(IMAGE_TAG_BASE)-$@:$(VERSION)
 
 ##@ Build
+build-daemon: manifests generate fmt vet ## Build standalone nnf-datamovement daemon
+	GOOS=linux GOARCH=amd64 go build -o bin/nnf-dm daemons/compute/server/main.go
 
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/daemons/compute/server/nnf-dm.spec
+++ b/daemons/compute/server/nnf-dm.spec
@@ -21,7 +21,7 @@ Near Node Flash data movement through the data movement API.
 %setup -q
 
 %build
-GOOS=linux GOARCH=amd64 go build -o bin/nnf-dm
+make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/


### PR DESCRIPTION
The `%build` section of the RPM packages referenced the wrong source files when compiling.  Fix this by adding a "build-daemons" target to the Makefile and then invoking that target in the spec file. This behavior is analogous to the way it was handled for the dws clientmount daemons.