### PR TITLE
Change DM Manager to use port 22 for ssh/mpirun + update nnf-mfu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt install -y bash
 
 # The following lines are from the mpiFileUtils (nnf-mfu) Dockerfile;
 # do not change them unless you know what it is you are doing
-ARG port=2222
+ARG port=22
 RUN sed -i "s/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g" /etc/ssh/ssh_config \
     && sed -i "s/[ #]\(.*Port \).*/ \1$port/g" /etc/ssh/ssh_config \
     && echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,7 @@ RUN apt install -y bash
 
 # The following lines are from the mpiFileUtils (nnf-mfu) Dockerfile;
 # do not change them unless you know what it is you are doing
-ARG port=22
 RUN sed -i "s/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g" /etc/ssh/ssh_config \
-    && sed -i "s/[ #]\(.*Port \).*/ \1$port/g" /etc/ssh/ssh_config \
     && echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config
 
 # Copy the executable and execute

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: worker
-          image: ghcr.io/nearnodeflash/nnf-mfu:82aa3c4b6655433dacbe3294ad359161c62219c6
+          image: ghcr.io/nearnodeflash/nnf-mfu:latest
           command: 
             - /usr/sbin/sshd
           args:


### PR DESCRIPTION
The DM manager was configured to use port 2222. However, the DM worker nodes running sshd are only listening on port 22. To simplify things, DM manager has gone back to port 22.

Additionally, the worker image was updated to track the latest version of nnf-mfu.

Tested in kind VM. The manager can hit the worker via mpirun now that it's targeting port 22:

```
$ kubectl -n nnf-dm-system exec nnf-dm-controller-manager-587495bc7-qrxhg -c manager -- mpirun --allow-run-as-root --host 10-244-3-3.dm.nnf-dm-system hostname
Warning: Permanently added '10-244-3-3.dm.nnf-dm-system,10.244.3.3' (ECDSA) to the list of known hosts.
nnf-dm-worker-8w7cs
```

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>