### PR TITLE
Github-84: Add commit hash to RPM builds

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -22,6 +22,7 @@ jobs:
           dnf install -y rpm-build rpmdevtools git make
           dnf module -y install go-toolset 
           rpmdev-setuptree
+          echo $GITHUB_SHA > .commit
           tar -czf /github/home/rpmbuild/SOURCES/nnf-datamovement-1.0.tar.gz --transform 's,^,nnf-datamovement-1.0/,' .
       - name: build rpms
         run: rpmbuild -ba daemons/compute/server/nnf-dm.spec

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ container-unit-test: .version ## Run tests inside a container image
 
 ##@ Build
 
-build-daemon: COMMIT_HASH = $(shell git rev-parse --short HEAD)
+build-daemon: COMMIT_HASH?=$(shell git rev-parse --short HEAD)
 build-daemon: PACKAGE = github.com/NearNodeFlash/nnf-dm/daemons/compute/server/version
 build-daemon: manifests generate fmt vet ## Build standalone nnf-datamovement daemon
 	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).commitHash=$(COMMIT_HASH)'" -o bin/nnf-dm daemons/compute/server/main.go

--- a/daemons/compute/server/nnf-dm.spec
+++ b/daemons/compute/server/nnf-dm.spec
@@ -21,7 +21,7 @@ Near Node Flash data movement through the data movement API.
 %setup -q
 
 %build
-make build-daemon
+COMMIT_HASH=$(cat .commit) make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/


### PR DESCRIPTION
Use the GITHUB_SHA environment variable provided in the github action and save it in the file .commit. The RPM build will use the value in this file instead of the output provided by the git command in the Makefile. This allows the git hash to be set when building from the source RPM.