### PR TITLE
RABSW-1150: Add ServiceAccount for nnf-dm daemon

### DIFF
--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: daemon-role
+rules:
+- apiGroups:
+  - cray.hpe.com
+  resources:
+  - lustrefilesystems
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - clientmounts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - clientmounts/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - systemconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfdatamovements
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfdatamovements/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - nnf.cray.hpe.com
+  resources:
+  - nnfdatamovements/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/daemon_role_binding.yaml
+++ b/config/rbac/daemon_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: daemon-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: daemon-role
+subjects:
+- kind: ServiceAccount
+  name: daemon
+  namespace: system

--- a/config/rbac/daemon_service_account.yaml
+++ b/config/rbac/daemon_service_account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: daemon
+  namespace: system
+---
+# As of Kubernetes 1.24, ServiceAccount tokens are no longer automatically
+# generated. Instead, manually create the secret and the token key in the
+# data field will be automatically set.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: daemon
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: daemon
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- daemon_service_account.yaml
+- daemon_role.yaml
+- daemon_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable


### PR DESCRIPTION
Add a ServiceAccount for clientmountd that only allows access to the resources that the nnf-dm daemon needs.