### PR TITLE
nnf-dm: Increase k8s client QPS and Burst

### DIFF
--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -350,7 +350,6 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 						}
 						cmdStatus.DeepCopyInto(dm.Status.CommandStatus)
 
-						log.Info("Updating Progress", "CommandStatus", dm.Status.CommandStatus)
 						return r.Status().Update(ctx, dm)
 					})
 

--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -286,7 +286,7 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	go func() {
 		// Use a MultiWriter so that we can parse the output and save the full output at the end
 		var combinedOutBuf, parseBuf bytes.Buffer
-		cmd.Stdout = io.MultiWriter(os.Stdout, &parseBuf, &combinedOutBuf)
+		cmd.Stdout = io.MultiWriter(&parseBuf, &combinedOutBuf)
 		cmd.Stderr = cmd.Stdout // Combine stderr/stdout
 
 		// Use channels to sync progress collection and cmd.Wait().

--- a/daemons/compute/server/servers/server.go
+++ b/daemons/compute/server/servers/server.go
@@ -36,6 +36,9 @@ type ServerOptions struct {
 	nodeName  string
 	sysConfig string
 	simulated bool
+
+	k8sQPS   int
+	k8sBurst int
 }
 
 func GetOptions() (*ServerOptions, error) {
@@ -47,6 +50,12 @@ func GetOptions() (*ServerOptions, error) {
 		tokenFile: os.Getenv("NNF_DATA_MOVEMENT_SERVICE_TOKEN_FILE"),
 		certFile:  os.Getenv("NNF_DATA_MOVEMENT_SERVICE_CERT_FILE"),
 		simulated: false,
+
+		// These options adjust the client-side rate-limiting for k8s. The new defaults are 50 and
+		// 100 (rather than 5, 10). See more info https://github.com/kubernetes/kubernetes/pull/116121
+		// According to that PR, it appears that client-side rate-limiting is going away.
+		k8sQPS:   50,
+		k8sBurst: 100,
 	}
 
 	flag.StringVar(&opts.host, "kubernetes-service-host", opts.host, "Kubernetes service host address")
@@ -57,6 +66,8 @@ func GetOptions() (*ServerOptions, error) {
 	flag.StringVar(&opts.certFile, "service-cert-file", opts.certFile, "Path to the NNF data movement service certificate")
 	flag.StringVar(&opts.sysConfig, "sys-config", "default", "Name of the system configuration containing this compute resource")
 	flag.BoolVar(&opts.simulated, "simulated", opts.simulated, "Run in simulation mode where no requests are sent to the server")
+	flag.IntVar(&opts.k8sQPS, "kubernetes-qps", opts.k8sQPS, "Kubernetes client queries per second (QPS)")
+	flag.IntVar(&opts.k8sBurst, "kubernetes-burst", opts.k8sBurst, "Kubernetes client additional concurrent calls above QPS")
 	flag.Parse()
 	return &opts, nil
 }

--- a/daemons/compute/server/servers/server_default.go
+++ b/daemons/compute/server/servers/server_default.go
@@ -147,6 +147,8 @@ func CreateDefaultServer(opts *ServerOptions) (*defaultServer, error) {
 			TLSClientConfig: tlsClientConfig,
 			BearerToken:     string(token),
 			BearerTokenFile: opts.tokenFile,
+			QPS:             float32(opts.k8sQPS),
+			Burst:           opts.k8sBurst,
 		}
 	}
 


### PR DESCRIPTION
The default values of 5 and 10 are impacting the creation of DM requests via the Copy Offload API. These values have been increased to 50 and
100. Command line parameters have been added to adjust these.

Additionally, update the go client to create the DM requests concurrently and make the simulated server thread safe.

Reduce data movement log output