### PR TITLE
Copy Offload API: Add generated documentation

### DIFF
--- a/daemons/compute/Readme.md
+++ b/daemons/compute/Readme.md
@@ -1,6 +1,6 @@
 # Data Movement
 
-This readme explains the Data Movement Daemon (nnf-dm) and it's corresponding API (Copy Offload API).
+This readme explains the Data Movement Daemon (nnf-dm) and its corresponding API (Copy Offload API).
 
 There are also some example clients that show how to use the Copy Offload API.
 

--- a/daemons/compute/Readme.md
+++ b/daemons/compute/Readme.md
@@ -1,20 +1,26 @@
 # Data Movement
 
+This readme explains the Data Movement Daemon (nnf-dm) and it's corresponding API (Copy Offload API).
+
+There are also some example clients that show how to use the Copy Offload API.
+
+## Data Movement Daemon
+
 The nnf-dm service is a compute resident daemon that provides an interface for submitting copy offload requests to the Rabbit.
 
-## Build
+### Build
 
 The nnf-dm service resides in [./server](./server) directory and can be built using `go build -o nnf-dm`
 
-## Installation
+### Installation
 
 Copy the nnf-dm daemon to a suitable location such as `/usr/bin`. After defining the necessary [environmental variables](#environmental-variables), install the daemon by running `nnf-dm install`. Verify the daemon is running using `systemctl status nnf-dm`
 
-### Authentication
+#### Authentication
 
 NNF software defines a Kubernetes service account for communicating data movement requests to the kubeapi server. The token file and certificate file can be downloaded by running `cert-load.sh` and verified with `cert-test.sh` The token file and certificate file must be provided to the nnf-dm daemon.
 
-### Customizing the Daemon Configuration
+#### Customizing the Daemon Configuration
 
 Installing the nnf-dm daemon will create a default configuration located at `/etc/systemd/system/nnf-dm.service`. The default configuration created on installation is sparse as the use of environmental variables is assumed. If desired, one can edit the configuration with the [command line options](#command-line-options). An example is show below.
 
@@ -37,7 +43,7 @@ Restart=on-failure
 WantedBy=multi-user.target
 ```
 
-### Daemon Configuration Overrides
+#### Daemon Configuration Overrides
 
 systemd can be used to create an override file that is useful for non-standard behavior of the data movement service. Run `systemctl edit nnf-dm` to create or edit the override file.
 
@@ -49,7 +55,7 @@ ExecStart=
 ExecStart=/root/nnf-dm --simulated
 ```
 
-## Environmental Variables
+### Environmental Variables
 
 | Name | Description |
 | ---- | ----------- |
@@ -60,7 +66,7 @@ ExecStart=/root/nnf-dm --simulated
 | `NNF_DATA_MOVEMENT_SERVICE_TOKEN_FILE` | Specifies the path to the NNF Data Movement service token file |
 | `NNF_DATA_MOVEMENT_SERVICE_CERT_FILE`  | Specifies the path to the NNF Data Movement service certificate file |
 
-## Command Line Options
+### Command Line Options
 
 Command line options are defined below. Most default to their corresponding environmental variables of the same name in upper-case with hyphens replaced by underscores
 
@@ -74,196 +80,57 @@ Command line options are defined below. Most default to their corresponding envi
 | `--nnf-data-movement-service-token-file=[PATH]` | `NNF_DATA_MOVEMENT_SERVICE_TOKEN_FILE` | Specifies the path to the NNF Data Movement service token file |
 | `--nnf-data-movement-service-cert-file=[PATH]` | `NNF_DATA_MOVEMENT_SERVICE_CERT_FILE`  | Specifies the path to the NNF Data Movement service certificate file |
 
-# Data Movement Interface
+## Data Movement Interface (Copy Offload API)
 
-The nnf-dm service uses Protocol Buffers to define a set of APIs for initiating, querying, canceling and deleting data movement requests. The definitions for these can be found in [./api/datamovement.proto](./api/datamovement.proto) file. Consulting this file should be done in addition to the context in this section to ensure the latest API definitions are used.
+The nnf-dm service uses Protocol Buffers to define a set of APIs for initiating, querying, canceling and deleting data movement requests. The definitions for these can be found in [./api/datamovement.proto](./api/datamovement.proto) file.
 
-## Common fields for all requests
+### Common fields for all requests
 
 Each nnf-dm request contains a Workflow message containing the Name and Namespace fields. WLM must provide these values to the user application that are then provided to the data-movement API. The recommended implementation is to use environmental variables.
 
-### Workflow
+#### Workflow
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `name` | string | Name of the workflow that is associated with this data movement request. WLM must provide this as an environmental variable (i.e. `DW_WORKFLOW_NAME`) |
-| `namespace` | string | Namespace of the workflow that is associated with this data movement request. WLM must provide this as an environmental variable (i.e. `DW_WORKFLOW_NAMESPACE`) |
+| `namespace` | string | Namespace of the workflow that is associated with this data movement request. WLM can provide this as an environmental variable (i.e. `DW_WORKFLOW_NAMESPACE`) |
 
-## Creating a data movement request
+### API Definition
 
-### Create Request
+See the generated [Copy Offload API Documentation](./copy-offload-api.html) for the full API definition.
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `workflow` | Workflow | The name and namespace of the initiating workflow |
-| `source` | string | The source file or directory |
-| `destination` | string | The destination file or directory |
-| `dryrun` | bool | If True, the data movement command runs `/bin/true` rather than perform actual data movement |
-| `dcpOptions` | string | Additional options to pass to `dcp` (to perform data movement) |
+This file is generated by running `./proto-gen.sh`, which also creates example clients for Go and Python. See more below.
 
-### Create Response
+## Example Clients
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `uid` | string | The unique identifier for the created data movement resource if `Status` is Success |
-| `status` | Status | Status of the data movement create request |
-| `message` | string | String providing detailed message pertaining to the current status of the create request |
+### Example Client Generation
 
-#### Create Response `Status`
+#### Go and Python
 
-| Value | Name | Description |
-| ----- | ---- | ----------- |
-| 0 | Success | The data movement resource created successfully |
-| 1 | Failed | The data movement resource failed to create. See `message` field for more information |
+To build the generated code used for the Go and Python example clients, run `./proto-gen.sh`. This will also generate the documentation for the API.
 
-## Query the status of a data movement request
+`client-go` and `client-py` will have updates to the generated files when the API changes.
 
-### Status Request
+#### C and C++
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `workflow` | Workflow | The name and namespace of the initiating workflow |
-| `uid` | string | The unique identifier for the created data movement resource |
-| `maxWaitTime` | int64 | The maximum time in seconds to wait for completion of the data movement resource. Negative values imply an indefinite wait |
+For the C and C++ clients, the clients must be built to generate the source code to support the API. Run the `Makefiles` in the `_client-c`, `client-cpp`, and `lib-cpp` directories to update the generated API files.
 
-### Status Response
+**Note**: `lib-cpp` must still be updated manually to support changes to the API, as it is a wrapper around the generated C++ files.
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `state` | State | Current state of the data movement request |
-| `status` | Status | Current status of the data movement request |
-| `message` | string | String providing detailed message pertaining to the current state/status of the request |
-| `commandStatus` | CommandStatus | Status of the data movement command. Includes progress, timing, and last message |
-| `startTime` | string | The start time of the data movement operation |
-| `endTime` | string | The end time of the data movement operation |
+### Go
 
-#### Status Response `State`
+The Go client, which resides in `client-go/`, is the most customizable client example. It demonstrates a number of command line options to configure the Create request. It provides a debug hook to _not_ delete the request after completion, so one can test that the requests are cleaned up as part of the workflow.
 
-| Value | Name | Description |
-| ----- | ---- | ----------- |
-| 0 | Pending | The request is created but has a pending status |
-| 1 | Starting | The request was created and is in the act of starting |
-| 2 | Running | The data movement request is actively running |
-| 3 | Completed | The data movement request has completed |
-| 4 | Cancelling | The data movement request has started the cancellation process |
+### C
 
-#### Status Response `Status`
-
-| Value | Name | Description |
-| ----- | ---- | ----------- |
-| 0 | Invalid | The request was found to be invalid. See `message` for details |
-| 1 | Not Found | The request with the supplied UID was not found |
-| 2 | Success | The request completed with success |
-| 3 | Failed | The request failed. See `message` for details |
-
-#### Status Response `CommandStatus`
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| command | string | The full command that is performing data movement |
-| progress| int32 | The progress percentage of the data movement (e.g. 50) |
-| elapsedTime | string | The elapsed time of the data movement (e.g. 25s) |
-| lastMessage | string | The most recent line of output from the data movement command |
-| lastMessageTime | string | The time of `lastMessage` |
-
-## List the data movement requests
-
-`namespace` and `workflow` must be supplied in order to retrieve data movement
-requests. An empty list of `uids` will be returned if there are no data movement
-requests that match both `namespace` and `workflow`.
-
-### List Request
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `workflow` | Workflow | The name and namespace of the initiating workflow |
-
-### List Response
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `uids` | string[] | List of data movement requests associated with the given workflow and namespace. |
-
-## Cancel a data movement request
-
-Data movement requests can be cancelled after creation of a data movement request. Cancel Responses
-will be sent back after the Cancellation has been successfully (or unsuccessfully) initiated. The
-user can then poll with a Status Request to verify the end result of the data movement request to
-ensure the cancellation was successful.
-
-While the data movement is being cancelled, a Status Response will report a state of `Cancelling`
-until the Cancellation is complete. At that time, a state of `Completed` with a status of
-`Cancelled` will be returned. See the Status Response section above.
-
-### Cancel Request
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `workflow` | Workflow | The name and namespace of the initiating workflow |
-| `uid` | string | The unique identifier for the data movement resource to be cancelled |
-
-### Cancel Response
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `status` | Status | Cancel status of the data movement request |
-| `message` | string | String providing detailed message pertaining to the cancellation of the request |
-
-#### Cancel Response `Status`
-
-| Value | Name | Description |
-| ----- | ---- | ----------- |
-| 0 | Invalid | The cancel request was found to be invalid |
-| 1 | Not Found | The request with the supplied UID was not found |
-| 2 | Success | The data movement request was cancelled successfully |
-| 3 | Failed | The data movement request cannot be canceled |
-
-## Delete a data movement request
-
-Data movement requests can be deleted once a data movement request has been completed (successful or
-otherwise). Delete Responses will be sent back after the Deletion has been successfully (or
-unsuccessfully) initiated. The user can then use a Status Request to verify the end result of the
-data movement request to ensure the deletion was successful.
-
-### Delete Request
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `workflow` | Workflow | The name and namespace of the initiating workflow |
-| `uid` | string | The unique identifier for the data movement resource |
-
-### Delete Response
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `status` | Status | Deletion status of the data movement request |
-| `message` | string | String providing detailed message pertaining to the deletion of the request |
-
-#### Delete Response `Status`
-
-| Value | Name | Description |
-| ----- | ---- | ----------- |
-| 0 | Invalid | The delete request was found to be invalid |
-| 1 | Not Found | The request with the supplied UID was not found |
-| 2 | Success | The data movement request was deleted successfully |
-| 3 | Active | The data movement request is currently active and cannot be deleted |
-
-# Example Clients
-
-## Go
-
-The Go client, which resides in `./client-go/`, is the most customizable client example. It demonstrates a number of command line options to configure the Create request. It provides a debug hook to _not_ delete the request after completion, so one can test that the requests are cleaned up as part of the workflow.
-
-## C
-
-The C client, which resides in `./_client-c/`, is a simple client that uses CGo as an interface to the server. (The leading underscore "\_" in the directory is so Go ignores directory as part of a larger repository build). As there is no native C GRPC implementation, Go is used to interface with the GRPC server while providing an interface to the C code. A Makefile is provided to build the various components and assemble it into a final executable.
+The C client, which resides in `_client-c/`, is a simple client that uses CGo as an interface to the server. (The leading underscore "\_" in the directory is so Go ignores directory as part of a larger repository build). As there is no native C GRPC implementation, Go is used to interface with the GRPC server while providing an interface to the C code. A Makefile is provided to build the various components and assemble it into a final executable.
 
 The C client should not be used for anything more than rapid prototyping. No new features will be added to the C client.
 
-## C++
+### C++
 
-The C++ client, which resides in `./client-cpp/`, is a simple client that uses [gRPC C++](https://grpc.io/docs/languages/cpp/).
+The C++ client, which resides in `client-cpp/`, is a simple client that uses [gRPC C++](https://grpc.io/docs/languages/cpp/).
 
-## Python
+### Python
 
-The Python client, which resides in `./client-py/`, is a very simple client. No customization options are provided
+The Python client, which resides in `client-py/`, is a very simple client. No customization options are provided

--- a/daemons/compute/api/datamovement.proto
+++ b/daemons/compute/api/datamovement.proto
@@ -26,175 +26,210 @@ import "google/protobuf/empty.proto";
 
 package datamovement;
 
-// DataMover service definition describes the API for perform data movement
-// for NNF storage. 
+// DataMover service definition describes the API for perform data movement for NNF storage.
 service DataMover {
-    // Version sends a request to the data movement daemon and returns a response containing
-    // details on the current build version and supported API versions.
+    // Version sends a request to the data movement daemon and returns a response containing details on the current build version and supported API versions.
     rpc Version (google.protobuf.Empty) returns (DataMovementVersionResponse) {}
 
-    // Create sends a new data movement request identified by source and destination fields. It returns
-    // a response containing a unique identifier which can be used to query the status of the request.
+    // Create sends a new data movement request identified by source and destination fields. It returns a response containing a unique identifier which can be used to query the status of the request.
     rpc Create (DataMovementCreateRequest) returns (DataMovementCreateResponse) {}
 
-    // Status requests the status of a previously submitted data movement request. It accepts a unique
-    // identifier that identifies the request and returns a status message.
+    // Status requests the status of a previously submitted data movement request. It accepts a unique identifier that identifies the request and returns a status message.
     rpc Status (DataMovementStatusRequest) returns (DataMovementStatusResponse) {}
 
-    // Delete will attempt to delete a completed data movement request. It accepts a unique identifier
-    // that identifies the request and returns the status of the delete operation.
+    // Delete will attempt to delete a completed data movement request. It accepts a unique identifier that identifies the request and returns the status of the delete operation.
     rpc Delete (DataMovementDeleteRequest) returns (DataMovementDeleteResponse) {}
 
     // List returns all current data movement requests for a given namespace and workflow.
     rpc List (DataMovementListRequest) returns (DataMovementListResponse) {}
 
-    // Cancel will attempt to stop a data movement request. It accepts a unique identifier
-    // that identifies the request and returns the status of the cancel operation.
+    // Cancel will attempt to stop a data movement request. It accepts a unique identifier that identifies the request and returns the status of the cancel operation.
     rpc Cancel (DataMovementCancelRequest) returns (DataMovementCancelResponse) {}
 }
 
-// The data movement version response returns information on the running data movement daemon. This includes
-// the build version and a list of supported API versions.
+// The data movement version response returns information on the running data movement daemon.
 message DataMovementVersionResponse {
+    // Current version of the API.
     string version = 1;
+
+    // List of supported API versions.
     repeated string apiVersions = 2;
 }
 
-// Data Movement workflow message contains identifying information for the workflow initiating the data movement
-// operation. This message must be nested in all Request messages.
+// Data Movement workflow message contains identifying information for the workflow initiating the data movement operation. This message must be nested in all Request messages.
 message DataMovementWorkflow {
+    // Name of the DWS workflow that is associated with this data movement request
     string name = 1;
+
+    // Namespace of the DWS workflow that is associated with this data movement request
     string namespace = 2;
 }
 
-// Data Movement workflows contain a CommandStatus object in the Status object. This information
-// relays the current state of the data movement progress. It includes the command, the progress
-// percentage (e.g. 0-100%), elapsed time of the data movement (duration string, e.g. 5s), the last
-// received message from the data movment command, and the time of that last message.
+// Data movement operations contain a CommandStatus in the Status object. This information relays the current state of the data movement progress.
 message DataMovementCommandStatus {
+    // Command used to perform Data Movement
     string command = 1;
-    int32 progress = 2;
-    string elapsedTime = 3;
-    string lastMessage = 4;
-    string lastMessageTime = 5;
 
+    // Progress percentage (0-100%) of the data movement based on the output of `dcp`. `dcp` must be present in the command.
+    int32 progress = 2;
+
+    // Duration of how long the operation has been running (e.g. 1m30s)
+    string elapsedTime = 3;
+
+    // The most recent line of output from the data movement command
+    string lastMessage = 4;
+
+    // The time (local) of lastMessage
+    string lastMessageTime = 5;
 }
 
-// The data movement create request message containing the source and destination files or directories. The
-// NNF Data Mover will perform a copy from source to the destination. Specify dryrun to instantiate
-// a new data movement request where the copy is simulated and not executed. dcpOptions allows for
-// adding additional options to the dcp command that performs data movement.
+// Create a Data Movement Request to perform data movement. NNF Data Movement will copy from source to the destination path.
 message DataMovementCreateRequest {
+
+    // The name and namespace of the initiating workflow
     DataMovementWorkflow workflow = 1;
+
+    // Source file or directory
     string source = 2;
+
+    // Destination file or directory
     string destination = 3;
+
+    // If True, the data movement command runs `/bin/true` rather than perform actual data movement
     bool dryrun = 4;
+
+    // Extra options to pass to `dcp` if present in the Data Movement command.
     string dcpOptions = 5;
 }
 
-// The data movement create response message contains a unique identifier amont all data movement requests for
-// the lifetime of the active job. The UID can be used to query for status of the request using the
-// data movement status request message.
+// The Data Movement Create Response to indicate the status of of the Data Movement Request.
 message DataMovementCreateResponse {
+    // The unique identifier for the created data movement resource if `Status` is Success
     string uid = 1;
 
     enum Status {
-        SUCCESS = 0;
-        FAILED = 1;
-        INVALID = 2;
+        SUCCESS = 0; // The data movement resource created successfully
+        FAILED = 1; // The data movement resource failed to create. See `message` field for more information
+        INVALID = 2; // Invalid request
     }
+
+    // Status of the DataMovementCreateRequest
     Status status = 2;
+
+    // Any extra information supplied with the status
     string message = 3;
 }
 
-// The data movement status request message permits users to query the status of a previously issued
-// data movement request by specifying the request's unique identifier.
+// The Data Movement Status Request message permits users to query the status of a Data Movement Request.
 message DataMovementStatusRequest {
+    // The name and namespace of the initiating workflow
     DataMovementWorkflow workflow = 1;
+
+    // UID of the Data Movement Request
     string uid = 2;
+
+    // The maximum time in seconds to wait for completion of the data movement resource. Negative values imply an indefinite wait
     int64 maxWaitTime = 3;
 }
 
-// The data movement status response message defines the current status of a data movement request. The
-// state field describes the current state of the request. The message field contains ancillary information
-// describing the data movement request. 
+// The Data Movement Status Response message defines the current status of a data movement request.
 message DataMovementStatusResponse {
     enum State {
-        PENDING = 0;
-        STARTING = 1;
-        RUNNING = 2;
-        COMPLETED = 3;
-        CANCELLING = 4;
-        UNKNOWN_STATE = 5;
+        PENDING = 0; // The request is created but has a pending status
+        STARTING = 1; // The request was created and is in the act of starting
+        RUNNING = 2; // The data movement request is actively running
+        COMPLETED = 3; // The data movement request has completed
+        CANCELLING = 4; // The data movement request has started the cancellation process
+        UNKNOWN_STATE = 5; // Unknown state
     }
+
+    // Current state of the Data Movement Request
     State state = 1;
 
     enum Status {
-        INVALID = 0;
-        NOT_FOUND = 1;
-        SUCCESS = 2;
-        FAILED = 3;
-        CANCELLED = 4;
-        UNKNOWN_STATUS = 5;
+        INVALID = 0; // The request was found to be invalid. See `message` for details
+        NOT_FOUND = 1; // The request with the supplied UID was not found
+        SUCCESS = 2; // The request completed with success
+        FAILED = 3; // The request failed. See `message` for details
+        CANCELLED = 4; // The request was cancelled
+        UNKNOWN_STATUS = 5; // Unknown status
     }
+
+    // Current status of the Data Movement Request
     Status status = 2;
+
+    // Any extra information supplied with the state/status
     string message = 3;
+
+    // Current state/progress of the Data Movement command
     DataMovementCommandStatus commandStatus = 4;
+
+    // The start time (local) of the data movement operation
     string startTime = 5;
+
+    // The end time (local) of the data movement operation
     string endTime = 6;
 }
 
-// The data movement delete request permits users to delete a completed data movement request (any request with a 
-// status of COMPLETED) by specifying the request's unique identifier.
+// The Data Movement Delete Request permits users to delete a completed data movement request (any request with a status of COMPLETED).
 message DataMovementDeleteRequest {
+    // The name and namespace of the initiating workflow
     DataMovementWorkflow workflow = 1;
+
+    //  The unique identifier for the data movement resource
     string uid = 2;
 }
 
-// The data movement delete response returns the status of the delete operation.
+// The Data Movement Delete Response returns the status of the delete operation.
 message DataMovementDeleteResponse {
     enum Status {
-        INVALID = 0;
-        NOT_FOUND = 1;
-        SUCCESS = 2;
-        ACTIVE = 3;
-        UNKNOWN = 4;
+        INVALID = 0; // The delete request was found to be invalid
+        NOT_FOUND = 1; // The request with the supplied UID was not found
+        SUCCESS = 2; // The data movement request was deleted successfully
+        ACTIVE = 3; // The data movement request is currently active and cannot be deleted
+        UNKNOWN = 4; // Unknown status
     }
+
+    // Status of the Data Movement Delete Request
     Status status = 1;
+
+    // Any extra information supplied with the status
     string message = 2;
 }
 
-// The data movement list request allows a user to get a list of the current
-// data movement requests. The user must supply the workflow and namespace
-// which will be used to filter the data movement requests for retrieval.
+// The Data Movement List Request allows a user to get a list of the current data movement requests for a given DWS Workflow.
 message DataMovementListRequest {
+    // The name and namespace of the initiating workflow
     DataMovementWorkflow workflow = 1;
 }
 
-// The data movement list response returns a list of the matching data movement
-// requests' uids
+// The Data Movement List Response returns a list of the matching data movement requests' UIDs
 message DataMovementListResponse {
+    // List of data movement requests associated with the given workflow and namespace
     repeated string uids = 1;
 }
 
-// The data movement cancel request permits users to iniatiate a cancellation of
-// a data movement request that is in progress.
+// The Data Movement Cancel Request permits users to initiate a cancellation of a data movement request that is in progress.
 message DataMovementCancelRequest {
+    // The name and namespace of the initiating workflow
     DataMovementWorkflow workflow = 1;
+
+    // The unique identifier for the data movement resource
     string uid = 2;
 }
 
-// The data movement cancel response returns the status of the cancel request.
-// The cancel process will begin upon success. This response does not indicate
-// that that cancel process has completed, but rather that it has been
-// initiated.
+// The Data Movement Cancel Response returns the status of the cancel request.  The cancel process will begin upon success. This response does not indicate that that cancel process has completed, but rather that it has been initiated.
 message DataMovementCancelResponse {
     enum Status {
-        INVALID = 0;
-        NOT_FOUND = 1;
-        SUCCESS = 2;
-        FAILED = 3;
+        INVALID = 0; // The cancel request was found to be invalid
+        NOT_FOUND = 1; // The request with the supplied UID was not found
+        SUCCESS = 2; // The data movement request was cancelled successfully
+        FAILED = 3; // The data movement request cannot be canceled
       }
+
+      // Status of the Data Movement Cancellation Request
       Status status = 1;
+
+      // Any extra information included with the status
       string message = 2;
 }

--- a/daemons/compute/client-go/api/datamovement.pb.go
+++ b/daemons/compute/client-go/api/datamovement.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Hewlett Packard Enterprise Development LP
+// Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 // Other additional copyright holders may be indicated within.
 //
 // The entirety of this work is licensed under the Apache License,
@@ -41,9 +41,9 @@ const (
 type DataMovementCreateResponse_Status int32
 
 const (
-	DataMovementCreateResponse_SUCCESS DataMovementCreateResponse_Status = 0
-	DataMovementCreateResponse_FAILED  DataMovementCreateResponse_Status = 1
-	DataMovementCreateResponse_INVALID DataMovementCreateResponse_Status = 2
+	DataMovementCreateResponse_SUCCESS DataMovementCreateResponse_Status = 0 // The data movement resource created successfully
+	DataMovementCreateResponse_FAILED  DataMovementCreateResponse_Status = 1 // The data movement resource failed to create. See `message` field for more information
+	DataMovementCreateResponse_INVALID DataMovementCreateResponse_Status = 2 // Invalid request
 )
 
 // Enum value maps for DataMovementCreateResponse_Status.
@@ -90,12 +90,12 @@ func (DataMovementCreateResponse_Status) EnumDescriptor() ([]byte, []int) {
 type DataMovementStatusResponse_State int32
 
 const (
-	DataMovementStatusResponse_PENDING       DataMovementStatusResponse_State = 0
-	DataMovementStatusResponse_STARTING      DataMovementStatusResponse_State = 1
-	DataMovementStatusResponse_RUNNING       DataMovementStatusResponse_State = 2
-	DataMovementStatusResponse_COMPLETED     DataMovementStatusResponse_State = 3
-	DataMovementStatusResponse_CANCELLING    DataMovementStatusResponse_State = 4
-	DataMovementStatusResponse_UNKNOWN_STATE DataMovementStatusResponse_State = 5
+	DataMovementStatusResponse_PENDING       DataMovementStatusResponse_State = 0 // The request is created but has a pending status
+	DataMovementStatusResponse_STARTING      DataMovementStatusResponse_State = 1 // The request was created and is in the act of starting
+	DataMovementStatusResponse_RUNNING       DataMovementStatusResponse_State = 2 // The data movement request is actively running
+	DataMovementStatusResponse_COMPLETED     DataMovementStatusResponse_State = 3 // The data movement request has completed
+	DataMovementStatusResponse_CANCELLING    DataMovementStatusResponse_State = 4 // The data movement request has started the cancellation process
+	DataMovementStatusResponse_UNKNOWN_STATE DataMovementStatusResponse_State = 5 // Unknown state
 )
 
 // Enum value maps for DataMovementStatusResponse_State.
@@ -148,12 +148,12 @@ func (DataMovementStatusResponse_State) EnumDescriptor() ([]byte, []int) {
 type DataMovementStatusResponse_Status int32
 
 const (
-	DataMovementStatusResponse_INVALID        DataMovementStatusResponse_Status = 0
-	DataMovementStatusResponse_NOT_FOUND      DataMovementStatusResponse_Status = 1
-	DataMovementStatusResponse_SUCCESS        DataMovementStatusResponse_Status = 2
-	DataMovementStatusResponse_FAILED         DataMovementStatusResponse_Status = 3
-	DataMovementStatusResponse_CANCELLED      DataMovementStatusResponse_Status = 4
-	DataMovementStatusResponse_UNKNOWN_STATUS DataMovementStatusResponse_Status = 5
+	DataMovementStatusResponse_INVALID        DataMovementStatusResponse_Status = 0 // The request was found to be invalid. See `message` for details
+	DataMovementStatusResponse_NOT_FOUND      DataMovementStatusResponse_Status = 1 // The request with the supplied UID was not found
+	DataMovementStatusResponse_SUCCESS        DataMovementStatusResponse_Status = 2 // The request completed with success
+	DataMovementStatusResponse_FAILED         DataMovementStatusResponse_Status = 3 // The request failed. See `message` for details
+	DataMovementStatusResponse_CANCELLED      DataMovementStatusResponse_Status = 4 // The request was cancelled
+	DataMovementStatusResponse_UNKNOWN_STATUS DataMovementStatusResponse_Status = 5 // Unknown status
 )
 
 // Enum value maps for DataMovementStatusResponse_Status.
@@ -206,11 +206,11 @@ func (DataMovementStatusResponse_Status) EnumDescriptor() ([]byte, []int) {
 type DataMovementDeleteResponse_Status int32
 
 const (
-	DataMovementDeleteResponse_INVALID   DataMovementDeleteResponse_Status = 0
-	DataMovementDeleteResponse_NOT_FOUND DataMovementDeleteResponse_Status = 1
-	DataMovementDeleteResponse_SUCCESS   DataMovementDeleteResponse_Status = 2
-	DataMovementDeleteResponse_ACTIVE    DataMovementDeleteResponse_Status = 3
-	DataMovementDeleteResponse_UNKNOWN   DataMovementDeleteResponse_Status = 4
+	DataMovementDeleteResponse_INVALID   DataMovementDeleteResponse_Status = 0 // The delete request was found to be invalid
+	DataMovementDeleteResponse_NOT_FOUND DataMovementDeleteResponse_Status = 1 // The request with the supplied UID was not found
+	DataMovementDeleteResponse_SUCCESS   DataMovementDeleteResponse_Status = 2 // The data movement request was deleted successfully
+	DataMovementDeleteResponse_ACTIVE    DataMovementDeleteResponse_Status = 3 // The data movement request is currently active and cannot be deleted
+	DataMovementDeleteResponse_UNKNOWN   DataMovementDeleteResponse_Status = 4 // Unknown status
 )
 
 // Enum value maps for DataMovementDeleteResponse_Status.
@@ -261,10 +261,10 @@ func (DataMovementDeleteResponse_Status) EnumDescriptor() ([]byte, []int) {
 type DataMovementCancelResponse_Status int32
 
 const (
-	DataMovementCancelResponse_INVALID   DataMovementCancelResponse_Status = 0
-	DataMovementCancelResponse_NOT_FOUND DataMovementCancelResponse_Status = 1
-	DataMovementCancelResponse_SUCCESS   DataMovementCancelResponse_Status = 2
-	DataMovementCancelResponse_FAILED    DataMovementCancelResponse_Status = 3
+	DataMovementCancelResponse_INVALID   DataMovementCancelResponse_Status = 0 // The cancel request was found to be invalid
+	DataMovementCancelResponse_NOT_FOUND DataMovementCancelResponse_Status = 1 // The request with the supplied UID was not found
+	DataMovementCancelResponse_SUCCESS   DataMovementCancelResponse_Status = 2 // The data movement request was cancelled successfully
+	DataMovementCancelResponse_FAILED    DataMovementCancelResponse_Status = 3 // The data movement request cannot be canceled
 )
 
 // Enum value maps for DataMovementCancelResponse_Status.
@@ -310,14 +310,15 @@ func (DataMovementCancelResponse_Status) EnumDescriptor() ([]byte, []int) {
 	return file_api_datamovement_proto_rawDescGZIP(), []int{12, 0}
 }
 
-// The data movement version response returns information on the running data movement daemon. This includes
-// the build version and a list of supported API versions.
+// The data movement version response returns information on the running data movement daemon.
 type DataMovementVersionResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Version     string   `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	// Current version of the API.
+	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	// List of supported API versions.
 	ApiVersions []string `protobuf:"bytes,2,rep,name=apiVersions,proto3" json:"apiVersions,omitempty"`
 }
 
@@ -367,14 +368,15 @@ func (x *DataMovementVersionResponse) GetApiVersions() []string {
 	return nil
 }
 
-// Data Movement workflow message contains identifying information for the workflow initiating the data movement
-// operation. This message must be nested in all Request messages.
+// Data Movement workflow message contains identifying information for the workflow initiating the data movement operation. This message must be nested in all Request messages.
 type DataMovementWorkflow struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name      string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Name of the DWS workflow that is associated with this data movement request
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Namespace of the DWS workflow that is associated with this data movement request
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 }
 
@@ -424,19 +426,21 @@ func (x *DataMovementWorkflow) GetNamespace() string {
 	return ""
 }
 
-// Data Movement workflows contain a CommandStatus object in the Status object. This information
-// relays the current state of the data movement progress. It includes the command, the progress
-// percentage (e.g. 0-100%), elapsed time of the data movement (duration string, e.g. 5s), the last
-// received message from the data movment command, and the time of that last message.
+// Data movement operations contain a CommandStatus in the Status object. This information relays the current state of the data movement progress.
 type DataMovementCommandStatus struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Command         string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
-	Progress        int32  `protobuf:"varint,2,opt,name=progress,proto3" json:"progress,omitempty"`
-	ElapsedTime     string `protobuf:"bytes,3,opt,name=elapsedTime,proto3" json:"elapsedTime,omitempty"`
-	LastMessage     string `protobuf:"bytes,4,opt,name=lastMessage,proto3" json:"lastMessage,omitempty"`
+	// Command used to perform Data Movement
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Progress percentage (0-100%) of the data movement based on the output of `dcp`. `dcp` must be present in the command.
+	Progress int32 `protobuf:"varint,2,opt,name=progress,proto3" json:"progress,omitempty"`
+	// Duration of how long the operation has been running (e.g. 1m30s)
+	ElapsedTime string `protobuf:"bytes,3,opt,name=elapsedTime,proto3" json:"elapsedTime,omitempty"`
+	// The most recent line of output from the data movement command
+	LastMessage string `protobuf:"bytes,4,opt,name=lastMessage,proto3" json:"lastMessage,omitempty"`
+	// The time (local) of lastMessage
 	LastMessageTime string `protobuf:"bytes,5,opt,name=lastMessageTime,proto3" json:"lastMessageTime,omitempty"`
 }
 
@@ -507,20 +511,22 @@ func (x *DataMovementCommandStatus) GetLastMessageTime() string {
 	return ""
 }
 
-// The data movement create request message containing the source and destination files or directories. The
-// NNF Data Mover will perform a copy from source to the destination. Specify dryrun to instantiate
-// a new data movement request where the copy is simulated and not executed. dcpOptions allows for
-// adding additional options to the dcp command that performs data movement.
+// Create a Data Movement Request to perform data movement. NNF Data Movement will copy from source to the destination path.
 type DataMovementCreateRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Workflow    *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
-	Source      string                `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	Destination string                `protobuf:"bytes,3,opt,name=destination,proto3" json:"destination,omitempty"`
-	Dryrun      bool                  `protobuf:"varint,4,opt,name=dryrun,proto3" json:"dryrun,omitempty"`
-	DcpOptions  string                `protobuf:"bytes,5,opt,name=dcpOptions,proto3" json:"dcpOptions,omitempty"`
+	// The name and namespace of the initiating workflow
+	Workflow *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	// Source file or directory
+	Source string `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	// Destination file or directory
+	Destination string `protobuf:"bytes,3,opt,name=destination,proto3" json:"destination,omitempty"`
+	// If True, the data movement command runs `/bin/true` rather than perform actual data movement
+	Dryrun bool `protobuf:"varint,4,opt,name=dryrun,proto3" json:"dryrun,omitempty"`
+	// Extra options to pass to `dcp` if present in the Data Movement command.
+	DcpOptions string `protobuf:"bytes,5,opt,name=dcpOptions,proto3" json:"dcpOptions,omitempty"`
 }
 
 func (x *DataMovementCreateRequest) Reset() {
@@ -590,17 +596,18 @@ func (x *DataMovementCreateRequest) GetDcpOptions() string {
 	return ""
 }
 
-// The data movement create response message contains a unique identifier amont all data movement requests for
-// the lifetime of the active job. The UID can be used to query for status of the request using the
-// data movement status request message.
+// The Data Movement Create Response to indicate the status of of the Data Movement Request.
 type DataMovementCreateResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Uid     string                            `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
-	Status  DataMovementCreateResponse_Status `protobuf:"varint,2,opt,name=status,proto3,enum=datamovement.DataMovementCreateResponse_Status" json:"status,omitempty"`
-	Message string                            `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	// The unique identifier for the created data movement resource if `Status` is Success
+	Uid string `protobuf:"bytes,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	// Status of the DataMovementCreateRequest
+	Status DataMovementCreateResponse_Status `protobuf:"varint,2,opt,name=status,proto3,enum=datamovement.DataMovementCreateResponse_Status" json:"status,omitempty"`
+	// Any extra information supplied with the status
+	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
 }
 
 func (x *DataMovementCreateResponse) Reset() {
@@ -656,16 +663,18 @@ func (x *DataMovementCreateResponse) GetMessage() string {
 	return ""
 }
 
-// The data movement status request message permits users to query the status of a previously issued
-// data movement request by specifying the request's unique identifier.
+// The Data Movement Status Request message permits users to query the status of a Data Movement Request.
 type DataMovementStatusRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Workflow    *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
-	Uid         string                `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
-	MaxWaitTime int64                 `protobuf:"varint,3,opt,name=maxWaitTime,proto3" json:"maxWaitTime,omitempty"`
+	// The name and namespace of the initiating workflow
+	Workflow *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	// UID of the Data Movement Request
+	Uid string `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	// The maximum time in seconds to wait for completion of the data movement resource. Negative values imply an indefinite wait
+	MaxWaitTime int64 `protobuf:"varint,3,opt,name=maxWaitTime,proto3" json:"maxWaitTime,omitempty"`
 }
 
 func (x *DataMovementStatusRequest) Reset() {
@@ -721,20 +730,24 @@ func (x *DataMovementStatusRequest) GetMaxWaitTime() int64 {
 	return 0
 }
 
-// The data movement status response message defines the current status of a data movement request. The
-// state field describes the current state of the request. The message field contains ancillary information
-// describing the data movement request.
+// The Data Movement Status Response message defines the current status of a data movement request.
 type DataMovementStatusResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	State         DataMovementStatusResponse_State  `protobuf:"varint,1,opt,name=state,proto3,enum=datamovement.DataMovementStatusResponse_State" json:"state,omitempty"`
-	Status        DataMovementStatusResponse_Status `protobuf:"varint,2,opt,name=status,proto3,enum=datamovement.DataMovementStatusResponse_Status" json:"status,omitempty"`
-	Message       string                            `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	CommandStatus *DataMovementCommandStatus        `protobuf:"bytes,4,opt,name=commandStatus,proto3" json:"commandStatus,omitempty"`
-	StartTime     string                            `protobuf:"bytes,5,opt,name=startTime,proto3" json:"startTime,omitempty"`
-	EndTime       string                            `protobuf:"bytes,6,opt,name=endTime,proto3" json:"endTime,omitempty"`
+	// Current state of the Data Movement Request
+	State DataMovementStatusResponse_State `protobuf:"varint,1,opt,name=state,proto3,enum=datamovement.DataMovementStatusResponse_State" json:"state,omitempty"`
+	// Current status of the Data Movement Request
+	Status DataMovementStatusResponse_Status `protobuf:"varint,2,opt,name=status,proto3,enum=datamovement.DataMovementStatusResponse_Status" json:"status,omitempty"`
+	// Any extra information supplied with the state/status
+	Message string `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	// Current state/progress of the Data Movement command
+	CommandStatus *DataMovementCommandStatus `protobuf:"bytes,4,opt,name=commandStatus,proto3" json:"commandStatus,omitempty"`
+	// The start time (local) of the data movement operation
+	StartTime string `protobuf:"bytes,5,opt,name=startTime,proto3" json:"startTime,omitempty"`
+	// The end time (local) of the data movement operation
+	EndTime string `protobuf:"bytes,6,opt,name=endTime,proto3" json:"endTime,omitempty"`
 }
 
 func (x *DataMovementStatusResponse) Reset() {
@@ -811,15 +824,16 @@ func (x *DataMovementStatusResponse) GetEndTime() string {
 	return ""
 }
 
-// The data movement delete request permits users to delete a completed data movement request (any request with a
-// status of COMPLETED) by specifying the request's unique identifier.
+// The Data Movement Delete Request permits users to delete a completed data movement request (any request with a status of COMPLETED).
 type DataMovementDeleteRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The name and namespace of the initiating workflow
 	Workflow *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
-	Uid      string                `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	// The unique identifier for the data movement resource
+	Uid string `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
 }
 
 func (x *DataMovementDeleteRequest) Reset() {
@@ -868,14 +882,16 @@ func (x *DataMovementDeleteRequest) GetUid() string {
 	return ""
 }
 
-// The data movement delete response returns the status of the delete operation.
+// The Data Movement Delete Response returns the status of the delete operation.
 type DataMovementDeleteResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Status  DataMovementDeleteResponse_Status `protobuf:"varint,1,opt,name=status,proto3,enum=datamovement.DataMovementDeleteResponse_Status" json:"status,omitempty"`
-	Message string                            `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Status of the Data Movement Delete Request
+	Status DataMovementDeleteResponse_Status `protobuf:"varint,1,opt,name=status,proto3,enum=datamovement.DataMovementDeleteResponse_Status" json:"status,omitempty"`
+	// Any extra information supplied with the status
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 }
 
 func (x *DataMovementDeleteResponse) Reset() {
@@ -924,14 +940,13 @@ func (x *DataMovementDeleteResponse) GetMessage() string {
 	return ""
 }
 
-// The data movement list request allows a user to get a list of the current
-// data movement requests. The user must supply the workflow and namespace
-// which will be used to filter the data movement requests for retrieval.
+// The Data Movement List Request allows a user to get a list of the current data movement requests for a given DWS Workflow.
 type DataMovementListRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The name and namespace of the initiating workflow
 	Workflow *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
 }
 
@@ -974,13 +989,13 @@ func (x *DataMovementListRequest) GetWorkflow() *DataMovementWorkflow {
 	return nil
 }
 
-// The data movement list response returns a list of the matching data movement
-// requests' uids
+// The Data Movement List Response returns a list of the matching data movement requests' UIDs
 type DataMovementListResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// List of data movement requests associated with the given workflow and namespace
 	Uids []string `protobuf:"bytes,1,rep,name=uids,proto3" json:"uids,omitempty"`
 }
 
@@ -1023,15 +1038,16 @@ func (x *DataMovementListResponse) GetUids() []string {
 	return nil
 }
 
-// The data movement cancel request permits users to iniatiate a cancellation of
-// a data movement request that is in progress.
+// The Data Movement Cancel Request permits users to initiate a cancellation of a data movement request that is in progress.
 type DataMovementCancelRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The name and namespace of the initiating workflow
 	Workflow *DataMovementWorkflow `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
-	Uid      string                `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	// The unique identifier for the data movement resource
+	Uid string `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
 }
 
 func (x *DataMovementCancelRequest) Reset() {
@@ -1080,17 +1096,16 @@ func (x *DataMovementCancelRequest) GetUid() string {
 	return ""
 }
 
-// The data movement cancel response returns the status of the cancel request.
-// The cancel process will begin upon success. This response does not indicate
-// that that cancel process has completed, but rather that it has been
-// initiated.
+// The Data Movement Cancel Response returns the status of the cancel request.  The cancel process will begin upon success. This response does not indicate that that cancel process has completed, but rather that it has been initiated.
 type DataMovementCancelResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Status  DataMovementCancelResponse_Status `protobuf:"varint,1,opt,name=status,proto3,enum=datamovement.DataMovementCancelResponse_Status" json:"status,omitempty"`
-	Message string                            `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Status of the Data Movement Cancellation Request
+	Status DataMovementCancelResponse_Status `protobuf:"varint,1,opt,name=status,proto3,enum=datamovement.DataMovementCancelResponse_Status" json:"status,omitempty"`
+	// Any extra information included with the status
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 }
 
 func (x *DataMovementCancelResponse) Reset() {

--- a/daemons/compute/client-go/api/datamovement_grpc.pb.go
+++ b/daemons/compute/client-go/api/datamovement_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Hewlett Packard Enterprise Development LP
+// Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 // Other additional copyright holders may be indicated within.
 //
 // The entirety of this work is licensed under the Apache License,
@@ -49,22 +49,17 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DataMoverClient interface {
-	// Version sends a request to the data movement daemon and returns a response containing
-	// details on the current build version and supported API versions.
+	// Version sends a request to the data movement daemon and returns a response containing details on the current build version and supported API versions.
 	Version(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*DataMovementVersionResponse, error)
-	// Create sends a new data movement request identified by source and destination fields. It returns
-	// a response containing a unique identifier which can be used to query the status of the request.
+	// Create sends a new data movement request identified by source and destination fields. It returns a response containing a unique identifier which can be used to query the status of the request.
 	Create(ctx context.Context, in *DataMovementCreateRequest, opts ...grpc.CallOption) (*DataMovementCreateResponse, error)
-	// Status requests the status of a previously submitted data movement request. It accepts a unique
-	// identifier that identifies the request and returns a status message.
+	// Status requests the status of a previously submitted data movement request. It accepts a unique identifier that identifies the request and returns a status message.
 	Status(ctx context.Context, in *DataMovementStatusRequest, opts ...grpc.CallOption) (*DataMovementStatusResponse, error)
-	// Delete will attempt to delete a completed data movement request. It accepts a unique identifier
-	// that identifies the request and returns the status of the delete operation.
+	// Delete will attempt to delete a completed data movement request. It accepts a unique identifier that identifies the request and returns the status of the delete operation.
 	Delete(ctx context.Context, in *DataMovementDeleteRequest, opts ...grpc.CallOption) (*DataMovementDeleteResponse, error)
 	// List returns all current data movement requests for a given namespace and workflow.
 	List(ctx context.Context, in *DataMovementListRequest, opts ...grpc.CallOption) (*DataMovementListResponse, error)
-	// Cancel will attempt to stop a data movement request. It accepts a unique identifier
-	// that identifies the request and returns the status of the cancel operation.
+	// Cancel will attempt to stop a data movement request. It accepts a unique identifier that identifies the request and returns the status of the cancel operation.
 	Cancel(ctx context.Context, in *DataMovementCancelRequest, opts ...grpc.CallOption) (*DataMovementCancelResponse, error)
 }
 
@@ -134,22 +129,17 @@ func (c *dataMoverClient) Cancel(ctx context.Context, in *DataMovementCancelRequ
 // All implementations must embed UnimplementedDataMoverServer
 // for forward compatibility
 type DataMoverServer interface {
-	// Version sends a request to the data movement daemon and returns a response containing
-	// details on the current build version and supported API versions.
+	// Version sends a request to the data movement daemon and returns a response containing details on the current build version and supported API versions.
 	Version(context.Context, *emptypb.Empty) (*DataMovementVersionResponse, error)
-	// Create sends a new data movement request identified by source and destination fields. It returns
-	// a response containing a unique identifier which can be used to query the status of the request.
+	// Create sends a new data movement request identified by source and destination fields. It returns a response containing a unique identifier which can be used to query the status of the request.
 	Create(context.Context, *DataMovementCreateRequest) (*DataMovementCreateResponse, error)
-	// Status requests the status of a previously submitted data movement request. It accepts a unique
-	// identifier that identifies the request and returns a status message.
+	// Status requests the status of a previously submitted data movement request. It accepts a unique identifier that identifies the request and returns a status message.
 	Status(context.Context, *DataMovementStatusRequest) (*DataMovementStatusResponse, error)
-	// Delete will attempt to delete a completed data movement request. It accepts a unique identifier
-	// that identifies the request and returns the status of the delete operation.
+	// Delete will attempt to delete a completed data movement request. It accepts a unique identifier that identifies the request and returns the status of the delete operation.
 	Delete(context.Context, *DataMovementDeleteRequest) (*DataMovementDeleteResponse, error)
 	// List returns all current data movement requests for a given namespace and workflow.
 	List(context.Context, *DataMovementListRequest) (*DataMovementListResponse, error)
-	// Cancel will attempt to stop a data movement request. It accepts a unique identifier
-	// that identifies the request and returns the status of the cancel operation.
+	// Cancel will attempt to stop a data movement request. It accepts a unique identifier that identifies the request and returns the status of the cancel operation.
 	Cancel(context.Context, *DataMovementCancelRequest) (*DataMovementCancelResponse, error)
 	mustEmbedUnimplementedDataMoverServer()
 }

--- a/daemons/compute/client-py/datamovement_pb2_grpc.py
+++ b/daemons/compute/client-py/datamovement_pb2_grpc.py
@@ -7,8 +7,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class DataMoverStub(object):
-    """DataMover service definition describes the API for perform data movement
-    for NNF storage. 
+    """DataMover service definition describes the API for perform data movement for NNF storage.
     """
 
     def __init__(self, channel):
@@ -50,37 +49,32 @@ class DataMoverStub(object):
 
 
 class DataMoverServicer(object):
-    """DataMover service definition describes the API for perform data movement
-    for NNF storage. 
+    """DataMover service definition describes the API for perform data movement for NNF storage.
     """
 
     def Version(self, request, context):
-        """Version sends a request to the data movement daemon and returns a response containing
-        details on the current build version and supported API versions.
+        """Version sends a request to the data movement daemon and returns a response containing details on the current build version and supported API versions.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Create(self, request, context):
-        """Create sends a new data movement request identified by source and destination fields. It returns
-        a response containing a unique identifier which can be used to query the status of the request.
+        """Create sends a new data movement request identified by source and destination fields. It returns a response containing a unique identifier which can be used to query the status of the request.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Status(self, request, context):
-        """Status requests the status of a previously submitted data movement request. It accepts a unique
-        identifier that identifies the request and returns a status message.
+        """Status requests the status of a previously submitted data movement request. It accepts a unique identifier that identifies the request and returns a status message.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def Delete(self, request, context):
-        """Delete will attempt to delete a completed data movement request. It accepts a unique identifier
-        that identifies the request and returns the status of the delete operation.
+        """Delete will attempt to delete a completed data movement request. It accepts a unique identifier that identifies the request and returns the status of the delete operation.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -94,8 +88,7 @@ class DataMoverServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def Cancel(self, request, context):
-        """Cancel will attempt to stop a data movement request. It accepts a unique identifier
-        that identifies the request and returns the status of the cancel operation.
+        """Cancel will attempt to stop a data movement request. It accepts a unique identifier that identifies the request and returns the status of the cancel operation.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -142,8 +135,7 @@ def add_DataMoverServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class DataMover(object):
-    """DataMover service definition describes the API for perform data movement
-    for NNF storage. 
+    """DataMover service definition describes the API for perform data movement for NNF storage.
     """
 
     @staticmethod

--- a/daemons/compute/copy-offload-api.html
+++ b/daemons/compute/copy-offload-api.html
@@ -1,0 +1,1200 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>Protocol Documentation</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>
+    <style>
+      body {
+        width: 60em;
+        margin: 1em auto;
+        color: #222;
+        font-family: "Ubuntu", sans-serif;
+        padding-bottom: 4em;
+      }
+
+      h1 {
+        font-weight: normal;
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+      }
+
+      h2 {
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+        margin: 1.5em 0;
+      }
+
+      h3 {
+        font-weight: normal;
+        border-bottom: 1px solid #aaa;
+        padding-bottom: 0.5ex;
+      }
+
+      a {
+        text-decoration: none;
+        color: #567e25;
+      }
+
+      table {
+        width: 100%;
+        font-size: 80%;
+        border-collapse: collapse;
+      }
+
+      thead {
+        font-weight: 700;
+        background-color: #dcdcdc;
+      }
+
+      tbody tr:nth-child(even) {
+        background-color: #fbfbfb;
+      }
+
+      td {
+        border: 1px solid #ccc;
+        padding: 0.5ex 2ex;
+      }
+
+      td p {
+        text-indent: 1em;
+        margin: 0;
+      }
+
+      td p:nth-child(1) {
+        text-indent: 0;  
+      }
+
+       
+      .field-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .field-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .field-table td:nth-child(3) {  
+        width: 6em;
+      }
+      .field-table td:nth-child(4) {  
+        width: auto;
+      }
+
+       
+      .extension-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(3) {  
+        width: 10em;
+      }
+      .extension-table td:nth-child(4) {  
+        width: 5em;
+      }
+      .extension-table td:nth-child(5) {  
+        width: auto;
+      }
+
+       
+      .enum-table td:nth-child(1) {  
+        width: 10em;
+      }
+      .enum-table td:nth-child(2) {  
+        width: 10em;
+      }
+      .enum-table td:nth-child(3) {  
+        width: auto;
+      }
+
+       
+      .scalar-value-types-table tr {
+        height: 3em;
+      }
+
+       
+      #toc-container ul {
+        list-style-type: none;
+        padding-left: 1em;
+        line-height: 180%;
+        margin: 0;
+      }
+      #toc > li > a {
+        font-weight: bold;
+      }
+
+       
+      .file-heading {
+        width: 100%;
+        display: table;
+        border-bottom: 1px solid #aaa;
+        margin: 4em 0 1.5em 0;
+      }
+      .file-heading h2 {
+        border: none;
+        display: table-cell;
+      }
+      .file-heading a {
+        text-align: right;
+        display: table-cell;
+      }
+
+       
+      .badge {
+        width: 1.6em;
+        height: 1.6em;
+        display: inline-block;
+
+        line-height: 1.6em;
+        text-align: center;
+        font-weight: bold;
+        font-size: 60%;
+
+        color: #89ba48;
+        background-color: #dff0c8;
+
+        margin: 0.5ex 1em 0.5ex -1em;
+        border: 1px solid #fbfbfb;
+        border-radius: 1ex;
+      }
+    </style>
+
+    
+    <link rel="stylesheet" type="text/css" href="stylesheet.css"/>
+  </head>
+
+  <body>
+
+    <h1 id="title">Protocol Documentation</h1>
+
+    <h2>Table of Contents</h2>
+
+    <div id="toc-container">
+      <ul id="toc">
+        
+          
+          <li>
+            <a href="#api%2fdatamovement.proto">api/datamovement.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCancelRequest"><span class="badge">M</span>DataMovementCancelRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCancelResponse"><span class="badge">M</span>DataMovementCancelResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCommandStatus"><span class="badge">M</span>DataMovementCommandStatus</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCreateRequest"><span class="badge">M</span>DataMovementCreateRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCreateResponse"><span class="badge">M</span>DataMovementCreateResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementDeleteRequest"><span class="badge">M</span>DataMovementDeleteRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementDeleteResponse"><span class="badge">M</span>DataMovementDeleteResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementListRequest"><span class="badge">M</span>DataMovementListRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementListResponse"><span class="badge">M</span>DataMovementListResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementStatusRequest"><span class="badge">M</span>DataMovementStatusRequest</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementStatusResponse"><span class="badge">M</span>DataMovementStatusResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementVersionResponse"><span class="badge">M</span>DataMovementVersionResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementWorkflow"><span class="badge">M</span>DataMovementWorkflow</a>
+                </li>
+              
+              
+                <li>
+                  <a href="#datamovement.DataMovementCancelResponse.Status"><span class="badge">E</span>DataMovementCancelResponse.Status</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementCreateResponse.Status"><span class="badge">E</span>DataMovementCreateResponse.Status</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementDeleteResponse.Status"><span class="badge">E</span>DataMovementDeleteResponse.Status</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementStatusResponse.State"><span class="badge">E</span>DataMovementStatusResponse.State</a>
+                </li>
+              
+                <li>
+                  <a href="#datamovement.DataMovementStatusResponse.Status"><span class="badge">E</span>DataMovementStatusResponse.Status</a>
+                </li>
+              
+              
+              
+                <li>
+                  <a href="#datamovement.DataMover"><span class="badge">S</span>DataMover</a>
+                </li>
+              
+            </ul>
+          </li>
+        
+        <li><a href="#scalar-value-types">Scalar Value Types</a></li>
+      </ul>
+    </div>
+
+    
+      
+      <div class="file-heading">
+        <h2 id="api/datamovement.proto">api/datamovement.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="datamovement.DataMovementCancelRequest">DataMovementCancelRequest</h3>
+        <p>The Data Movement Cancel Request permits users to initiate a cancellation of a data movement request that is in progress.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workflow</td>
+                  <td><a href="#datamovement.DataMovementWorkflow">DataMovementWorkflow</a></td>
+                  <td></td>
+                  <td><p>The name and namespace of the initiating workflow </p></td>
+                </tr>
+              
+                <tr>
+                  <td>uid</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The unique identifier for the data movement resource </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementCancelResponse">DataMovementCancelResponse</h3>
+        <p>The Data Movement Cancel Response returns the status of the cancel request.  The cancel process will begin upon success. This response does not indicate that that cancel process has completed, but rather that it has been initiated.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#datamovement.DataMovementCancelResponse.Status">DataMovementCancelResponse.Status</a></td>
+                  <td></td>
+                  <td><p>Status of the Data Movement Cancellation Request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Any extra information included with the status </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementCommandStatus">DataMovementCommandStatus</h3>
+        <p>Data movement operations contain a CommandStatus in the Status object. This information relays the current state of the data movement progress.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>command</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Command used to perform Data Movement </p></td>
+                </tr>
+              
+                <tr>
+                  <td>progress</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Progress percentage (0-100%) of the data movement based on the output of `dcp`. `dcp` must be present in the command. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>elapsedTime</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Duration of how long the operation has been running (e.g. 1m30s) </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lastMessage</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The most recent line of output from the data movement command </p></td>
+                </tr>
+              
+                <tr>
+                  <td>lastMessageTime</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The time (local) of lastMessage </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementCreateRequest">DataMovementCreateRequest</h3>
+        <p>Create a Data Movement Request to perform data movement. NNF Data Movement will copy from source to the destination path.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workflow</td>
+                  <td><a href="#datamovement.DataMovementWorkflow">DataMovementWorkflow</a></td>
+                  <td></td>
+                  <td><p>The name and namespace of the initiating workflow </p></td>
+                </tr>
+              
+                <tr>
+                  <td>source</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Source file or directory </p></td>
+                </tr>
+              
+                <tr>
+                  <td>destination</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Destination file or directory </p></td>
+                </tr>
+              
+                <tr>
+                  <td>dryrun</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>If True, the data movement command runs `/bin/true` rather than perform actual data movement </p></td>
+                </tr>
+              
+                <tr>
+                  <td>dcpOptions</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Extra options to pass to `dcp` if present in the Data Movement command. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementCreateResponse">DataMovementCreateResponse</h3>
+        <p>The Data Movement Create Response to indicate the status of of the Data Movement Request.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>uid</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The unique identifier for the created data movement resource if `Status` is Success </p></td>
+                </tr>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#datamovement.DataMovementCreateResponse.Status">DataMovementCreateResponse.Status</a></td>
+                  <td></td>
+                  <td><p>Status of the DataMovementCreateRequest </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Any extra information supplied with the status </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementDeleteRequest">DataMovementDeleteRequest</h3>
+        <p>The Data Movement Delete Request permits users to delete a completed data movement request (any request with a status of COMPLETED).</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workflow</td>
+                  <td><a href="#datamovement.DataMovementWorkflow">DataMovementWorkflow</a></td>
+                  <td></td>
+                  <td><p>The name and namespace of the initiating workflow </p></td>
+                </tr>
+              
+                <tr>
+                  <td>uid</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The unique identifier for the data movement resource </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementDeleteResponse">DataMovementDeleteResponse</h3>
+        <p>The Data Movement Delete Response returns the status of the delete operation.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#datamovement.DataMovementDeleteResponse.Status">DataMovementDeleteResponse.Status</a></td>
+                  <td></td>
+                  <td><p>Status of the Data Movement Delete Request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Any extra information supplied with the status </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementListRequest">DataMovementListRequest</h3>
+        <p>The Data Movement List Request allows a user to get a list of the current data movement requests for a given DWS Workflow.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workflow</td>
+                  <td><a href="#datamovement.DataMovementWorkflow">DataMovementWorkflow</a></td>
+                  <td></td>
+                  <td><p>The name and namespace of the initiating workflow </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementListResponse">DataMovementListResponse</h3>
+        <p>The Data Movement List Response returns a list of the matching data movement requests' UIDs</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>uids</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>List of data movement requests associated with the given workflow and namespace </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementStatusRequest">DataMovementStatusRequest</h3>
+        <p>The Data Movement Status Request message permits users to query the status of a Data Movement Request.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workflow</td>
+                  <td><a href="#datamovement.DataMovementWorkflow">DataMovementWorkflow</a></td>
+                  <td></td>
+                  <td><p>The name and namespace of the initiating workflow </p></td>
+                </tr>
+              
+                <tr>
+                  <td>uid</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>UID of the Data Movement Request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>maxWaitTime</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>The maximum time in seconds to wait for completion of the data movement resource. Negative values imply an indefinite wait </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementStatusResponse">DataMovementStatusResponse</h3>
+        <p>The Data Movement Status Response message defines the current status of a data movement request.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>state</td>
+                  <td><a href="#datamovement.DataMovementStatusResponse.State">DataMovementStatusResponse.State</a></td>
+                  <td></td>
+                  <td><p>Current state of the Data Movement Request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>status</td>
+                  <td><a href="#datamovement.DataMovementStatusResponse.Status">DataMovementStatusResponse.Status</a></td>
+                  <td></td>
+                  <td><p>Current status of the Data Movement Request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>message</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Any extra information supplied with the state/status </p></td>
+                </tr>
+              
+                <tr>
+                  <td>commandStatus</td>
+                  <td><a href="#datamovement.DataMovementCommandStatus">DataMovementCommandStatus</a></td>
+                  <td></td>
+                  <td><p>Current state/progress of the Data Movement command </p></td>
+                </tr>
+              
+                <tr>
+                  <td>startTime</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The start time (local) of the data movement operation </p></td>
+                </tr>
+              
+                <tr>
+                  <td>endTime</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The end time (local) of the data movement operation </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementVersionResponse">DataMovementVersionResponse</h3>
+        <p>The data movement version response returns information on the running data movement daemon.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>version</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Current version of the API. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>apiVersions</td>
+                  <td><a href="#string">string</a></td>
+                  <td>repeated</td>
+                  <td><p>List of supported API versions. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="datamovement.DataMovementWorkflow">DataMovementWorkflow</h3>
+        <p>Data Movement workflow message contains identifying information for the workflow initiating the data movement operation. This message must be nested in all Request messages.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Name of the DWS workflow that is associated with this data movement request </p></td>
+                </tr>
+              
+                <tr>
+                  <td>namespace</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Namespace of the DWS workflow that is associated with this data movement request </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+        <h3 id="datamovement.DataMovementCancelResponse.Status">DataMovementCancelResponse.Status</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>INVALID</td>
+                <td>0</td>
+                <td><p>The cancel request was found to be invalid</p></td>
+              </tr>
+            
+              <tr>
+                <td>NOT_FOUND</td>
+                <td>1</td>
+                <td><p>The request with the supplied UID was not found</p></td>
+              </tr>
+            
+              <tr>
+                <td>SUCCESS</td>
+                <td>2</td>
+                <td><p>The data movement request was cancelled successfully</p></td>
+              </tr>
+            
+              <tr>
+                <td>FAILED</td>
+                <td>3</td>
+                <td><p>The data movement request cannot be canceled</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="datamovement.DataMovementCreateResponse.Status">DataMovementCreateResponse.Status</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>SUCCESS</td>
+                <td>0</td>
+                <td><p>The data movement resource created successfully</p></td>
+              </tr>
+            
+              <tr>
+                <td>FAILED</td>
+                <td>1</td>
+                <td><p>The data movement resource failed to create. See `message` field for more information</p></td>
+              </tr>
+            
+              <tr>
+                <td>INVALID</td>
+                <td>2</td>
+                <td><p>Invalid request</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="datamovement.DataMovementDeleteResponse.Status">DataMovementDeleteResponse.Status</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>INVALID</td>
+                <td>0</td>
+                <td><p>The delete request was found to be invalid</p></td>
+              </tr>
+            
+              <tr>
+                <td>NOT_FOUND</td>
+                <td>1</td>
+                <td><p>The request with the supplied UID was not found</p></td>
+              </tr>
+            
+              <tr>
+                <td>SUCCESS</td>
+                <td>2</td>
+                <td><p>The data movement request was deleted successfully</p></td>
+              </tr>
+            
+              <tr>
+                <td>ACTIVE</td>
+                <td>3</td>
+                <td><p>The data movement request is currently active and cannot be deleted</p></td>
+              </tr>
+            
+              <tr>
+                <td>UNKNOWN</td>
+                <td>4</td>
+                <td><p>Unknown status</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="datamovement.DataMovementStatusResponse.State">DataMovementStatusResponse.State</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>PENDING</td>
+                <td>0</td>
+                <td><p>The request is created but has a pending status</p></td>
+              </tr>
+            
+              <tr>
+                <td>STARTING</td>
+                <td>1</td>
+                <td><p>The request was created and is in the act of starting</p></td>
+              </tr>
+            
+              <tr>
+                <td>RUNNING</td>
+                <td>2</td>
+                <td><p>The data movement request is actively running</p></td>
+              </tr>
+            
+              <tr>
+                <td>COMPLETED</td>
+                <td>3</td>
+                <td><p>The data movement request has completed</p></td>
+              </tr>
+            
+              <tr>
+                <td>CANCELLING</td>
+                <td>4</td>
+                <td><p>The data movement request has started the cancellation process</p></td>
+              </tr>
+            
+              <tr>
+                <td>UNKNOWN_STATE</td>
+                <td>5</td>
+                <td><p>Unknown state</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="datamovement.DataMovementStatusResponse.Status">DataMovementStatusResponse.Status</h3>
+        <p></p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>INVALID</td>
+                <td>0</td>
+                <td><p>The request was found to be invalid. See `message` for details</p></td>
+              </tr>
+            
+              <tr>
+                <td>NOT_FOUND</td>
+                <td>1</td>
+                <td><p>The request with the supplied UID was not found</p></td>
+              </tr>
+            
+              <tr>
+                <td>SUCCESS</td>
+                <td>2</td>
+                <td><p>The request completed with success</p></td>
+              </tr>
+            
+              <tr>
+                <td>FAILED</td>
+                <td>3</td>
+                <td><p>The request failed. See `message` for details</p></td>
+              </tr>
+            
+              <tr>
+                <td>CANCELLED</td>
+                <td>4</td>
+                <td><p>The request was cancelled</p></td>
+              </tr>
+            
+              <tr>
+                <td>UNKNOWN_STATUS</td>
+                <td>5</td>
+                <td><p>Unknown status</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+
+      
+
+      
+        <h3 id="datamovement.DataMover">DataMover</h3>
+        <p>DataMover service definition describes the API for perform data movement for NNF storage.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Method Name</td><td>Request Type</td><td>Response Type</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>Version</td>
+                <td><a href="#google.protobuf.Empty">.google.protobuf.Empty</a></td>
+                <td><a href="#datamovement.DataMovementVersionResponse">DataMovementVersionResponse</a></td>
+                <td><p>Version sends a request to the data movement daemon and returns a response containing details on the current build version and supported API versions.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Create</td>
+                <td><a href="#datamovement.DataMovementCreateRequest">DataMovementCreateRequest</a></td>
+                <td><a href="#datamovement.DataMovementCreateResponse">DataMovementCreateResponse</a></td>
+                <td><p>Create sends a new data movement request identified by source and destination fields. It returns a response containing a unique identifier which can be used to query the status of the request.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Status</td>
+                <td><a href="#datamovement.DataMovementStatusRequest">DataMovementStatusRequest</a></td>
+                <td><a href="#datamovement.DataMovementStatusResponse">DataMovementStatusResponse</a></td>
+                <td><p>Status requests the status of a previously submitted data movement request. It accepts a unique identifier that identifies the request and returns a status message.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Delete</td>
+                <td><a href="#datamovement.DataMovementDeleteRequest">DataMovementDeleteRequest</a></td>
+                <td><a href="#datamovement.DataMovementDeleteResponse">DataMovementDeleteResponse</a></td>
+                <td><p>Delete will attempt to delete a completed data movement request. It accepts a unique identifier that identifies the request and returns the status of the delete operation.</p></td>
+              </tr>
+            
+              <tr>
+                <td>List</td>
+                <td><a href="#datamovement.DataMovementListRequest">DataMovementListRequest</a></td>
+                <td><a href="#datamovement.DataMovementListResponse">DataMovementListResponse</a></td>
+                <td><p>List returns all current data movement requests for a given namespace and workflow.</p></td>
+              </tr>
+            
+              <tr>
+                <td>Cancel</td>
+                <td><a href="#datamovement.DataMovementCancelRequest">DataMovementCancelRequest</a></td>
+                <td><a href="#datamovement.DataMovementCancelResponse">DataMovementCancelResponse</a></td>
+                <td><p>Cancel will attempt to stop a data movement request. It accepts a unique identifier that identifies the request and returns the status of the cancel operation.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+
+        
+    
+
+    <h2 id="scalar-value-types">Scalar Value Types</h2>
+    <table class="scalar-value-types-table">
+      <thead>
+        <tr><td>.proto Type</td><td>Notes</td><td>C++</td><td>Java</td><td>Python</td><td>Go</td><td>C#</td><td>PHP</td><td>Ruby</td></tr>
+      </thead>
+      <tbody>
+        
+          <tr id="double">
+            <td>double</td>
+            <td></td>
+            <td>double</td>
+            <td>double</td>
+            <td>float</td>
+            <td>float64</td>
+            <td>double</td>
+            <td>float</td>
+            <td>Float</td>
+          </tr>
+        
+          <tr id="float">
+            <td>float</td>
+            <td></td>
+            <td>float</td>
+            <td>float</td>
+            <td>float</td>
+            <td>float32</td>
+            <td>float</td>
+            <td>float</td>
+            <td>Float</td>
+          </tr>
+        
+          <tr id="int32">
+            <td>int32</td>
+            <td>Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="int64">
+            <td>int64</td>
+            <td>Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="uint32">
+            <td>uint32</td>
+            <td>Uses variable-length encoding.</td>
+            <td>uint32</td>
+            <td>int</td>
+            <td>int/long</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="uint64">
+            <td>uint64</td>
+            <td>Uses variable-length encoding.</td>
+            <td>uint64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sint32">
+            <td>sint32</td>
+            <td>Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sint64">
+            <td>sint64</td>
+            <td>Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="fixed32">
+            <td>fixed32</td>
+            <td>Always four bytes. More efficient than uint32 if values are often greater than 2^28.</td>
+            <td>uint32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>uint32</td>
+            <td>uint</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="fixed64">
+            <td>fixed64</td>
+            <td>Always eight bytes. More efficient than uint64 if values are often greater than 2^56.</td>
+            <td>uint64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>uint64</td>
+            <td>ulong</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="sfixed32">
+            <td>sfixed32</td>
+            <td>Always four bytes.</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>int</td>
+            <td>int32</td>
+            <td>int</td>
+            <td>integer</td>
+            <td>Bignum or Fixnum (as required)</td>
+          </tr>
+        
+          <tr id="sfixed64">
+            <td>sfixed64</td>
+            <td>Always eight bytes.</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>int/long</td>
+            <td>int64</td>
+            <td>long</td>
+            <td>integer/string</td>
+            <td>Bignum</td>
+          </tr>
+        
+          <tr id="bool">
+            <td>bool</td>
+            <td></td>
+            <td>bool</td>
+            <td>boolean</td>
+            <td>boolean</td>
+            <td>bool</td>
+            <td>bool</td>
+            <td>boolean</td>
+            <td>TrueClass/FalseClass</td>
+          </tr>
+        
+          <tr id="string">
+            <td>string</td>
+            <td>A string must always contain UTF-8 encoded or 7-bit ASCII text.</td>
+            <td>string</td>
+            <td>String</td>
+            <td>str/unicode</td>
+            <td>string</td>
+            <td>string</td>
+            <td>string</td>
+            <td>String (UTF-8)</td>
+          </tr>
+        
+          <tr id="bytes">
+            <td>bytes</td>
+            <td>May contain any arbitrary sequence of bytes.</td>
+            <td>string</td>
+            <td>ByteString</td>
+            <td>str</td>
+            <td>[]byte</td>
+            <td>ByteString</td>
+            <td>string</td>
+            <td>String (ASCII-8BIT)</td>
+          </tr>
+        
+      </tbody>
+    </table>
+  </body>
+</html>
+

--- a/daemons/compute/proto-gen.sh
+++ b/daemons/compute/proto-gen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021, 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -17,8 +17,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if ! command -v protoc &> /dev/null; then
+    echo "protoc is not installed"
+    echo "see https://grpc.io/docs/protoc-installation/"
+    exit 1
+fi
+
+if ! command -v protoc-gen-doc &> /dev/null; then
+    echo "protoc-doc-gen plugin is not installed"
+    echo "run `go install  github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest`"
+    exit 1
+fi
+
 protoc --go_out=paths=source_relative:./client-go --go-grpc_out=paths=source_relative:./client-go \
-    ./api/datamovement.proto
+    --doc_out=. --doc_opt=html,copy-offload-api.html \
+    ./api/datamovement.proto \
+
+if ! command -v python3 -c "import grpc_tools.protoc" &> /dev/null; then
+    echo "python grpc_tools.protoc module is not installed"
+    exit 1
+fi
 
 python3 -m grpc_tools.protoc -I./api --python_out=./client-py --grpc_python_out=./client-py \
     ./api/datamovement.proto


### PR DESCRIPTION
Use protoc-gen-doc to generate HTML documentation for the Copy Offload
API. This way, the code is self documenting and we do not have to update
the readme for any changes.

Updated the readme to point to the generated API documenation and to add more
clarity in certain areas.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
