### PR TITLE
Remove reliance on cray.nnf.manager node label.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ kind-push: .version ## Push docker image to kind
 	# the nnf-dm-rsyncnode daemonset that is created by that deployment.
 	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 	${DOCKER} pull gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-	kind load docker-image --nodes `kubectl get node -l cray.nnf.manager=true --no-headers -o custom-columns=":metadata.name" | paste -d, -s -` gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+	kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
 
 minikube-push: VERSION ?= $(shell cat .version)
 minikube-push: .version

--- a/_setup-kind.sh
+++ b/_setup-kind.sh
@@ -30,8 +30,6 @@ echo "$(tput bold)Creating kind cluster with two worker nodes and /nnf mount $(t
 kind create cluster --wait 60s --image=kindest/node:v1.22.5 --config kind-config.yaml
 
 kubectl taint node kind-control-plane node-role.kubernetes.io/master:NoSchedule-
-kubectl label node kind-control-plane cray.nnf.manager=true
-kubectl label node kind-control-plane cray.wlm.manager=true
 
 # Label the kind-workers as rabbit nodes for the NLCMs.
 NODES=$(kubectl get nodes --no-headers | grep --invert-match "control-plane" | awk '{print $1}')

--- a/_setup-minikube.sh
+++ b/_setup-minikube.sh
@@ -31,8 +31,6 @@ minikube start --nodes 3
 
 
 kubectl taint node minikube node-role.kubernetes.io/master:NoSchedule-
-kubectl label node minikube cray.nnf.manager=true
-kubectl label node minikube cray.wlm.manager=true
 
 NODES=$(kubectl get nodes --no-headers | grep --invert-match "control-plane" | awk '{print $1}')
 for NODE in $NODES; do

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        cray.nnf.manager: "true"
       containers:
       - command:
         - /manager


### PR DESCRIPTION
This should just go to an available untainted worker node.