### PR TITLE
github-61: Add predicate for dm-workers

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -135,8 +136,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&DataMovementReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:         k8sManager.GetClient(),
+		Scheme:         k8sManager.GetScheme(),
+		WatchNamespace: corev1.NamespaceDefault,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Add a predicate that limits the nnf-dm-workers to watching NnfDataMovement resources in the Rabbit node namespace, and the nnf-dm-controller-manager to watching NnfDataMovement resources in the nnf-dm-system namespace.