### PR TITLE
Use bash to run dm commands

### DIFF
--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -273,7 +273,7 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		log.Info("MPI Hostfile preview", "first line", peekMpiHostfile(mpiHostfile))
 	}
 
-	cmd := exec.CommandContext(ctxCancel, cmdArgs[0], cmdArgs[1:]...)
+	cmd := exec.CommandContext(ctxCancel, "/bin/bash", "-c", strings.Join(cmdArgs, " "))
 
 	// Record the start of the data movement operation
 	now := metav1.NowMicro()

--- a/controllers/datamovement_controller_test.go
+++ b/controllers/datamovement_controller_test.go
@@ -64,6 +64,8 @@ var _ = Describe("Data Movement Test", func() {
 		const testLabelKey = "dm-test"
 		var testLabel string
 
+		cmdBashPrefix := "/bin/bash -c "
+
 		createFakeProgressScript := func() string {
 			f, err := os.CreateTemp(tmpDir, "fakeProgressOutput-*.sh")
 			Expect(err).ToNot(HaveOccurred())
@@ -228,7 +230,7 @@ var _ = Describe("Data Movement Test", func() {
 
 		Context("when the dm configmap has specified an overrideCmd", func() {
 			BeforeEach(func() {
-				dmCfgProfile.Command = "/bin/ls -l"
+				dmCfgProfile.Command = "ls -l"
 			})
 			It("should use that command instead of the default mpirun", func() {
 				Eventually(func(g Gomega) string {
@@ -238,13 +240,13 @@ var _ = Describe("Data Movement Test", func() {
 						cmd = dm.Status.CommandStatus.Command
 					}
 					return cmd
-				}).Should(Equal(dmCfgProfile.Command))
+				}).Should(Equal(cmdBashPrefix + dmCfgProfile.Command))
 			})
 		})
 
 		Context("when the dm configmap does not have $HOSTFILE in the command", func() {
 			BeforeEach(func() {
-				dmCfgProfile.Command = "/bin/ls -l"
+				dmCfgProfile.Command = "ls -l"
 			})
 			It("should use that command instead of the default mpirun", func() {
 				Eventually(func(g Gomega) string {
@@ -254,7 +256,7 @@ var _ = Describe("Data Movement Test", func() {
 						cmd = dm.Status.CommandStatus.Command
 					}
 					return cmd
-				}).Should(Equal(dmCfgProfile.Command))
+				}).Should(Equal(cmdBashPrefix + dmCfgProfile.Command))
 			})
 		})
 


### PR DESCRIPTION
This allows for more debugging when running data movement commands. For instance:

```
time mpirun ...
```