### PR TITLE
Trigger the workflow only on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,6 @@ on:
       - '*'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'releases/v*'
 
 env:
   # TEST_TARGET: Name of the testing target in the Dockerfile

--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -5,10 +5,6 @@ on:
       - '*'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'releases/v*'
 
 jobs:
   repo_version:


### PR DESCRIPTION
The 'push' and 'pull_request' triggers together are redundant in a PR, and cause the PR to get two builds.

The 'push' trigger is firing in a PR and on merge to master, so it should be sufficient.