### PR TITLE
Add dm.Status.Message back on DM failure

### DIFF
--- a/controllers/datamovement_controller.go
+++ b/controllers/datamovement_controller.go
@@ -406,6 +406,7 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			dm.Status.Status = nnfv1alpha1.DataMovementConditionReasonCancelled
 		} else if err != nil {
 			dm.Status.Status = nnfv1alpha1.DataMovementConditionReasonFailed
+			dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), combinedOutBuf.String())
 			resourceErr := dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("data movement operation failed: %s", combinedOutBuf.String()).WithFatal()
 			dm.Status.SetResourceErrorAndLog(resourceErr, log)
 		} else {


### PR DESCRIPTION
The Copy Offload API relies on this so the output can be relayed back to
the user.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
