### PR TITLE
Requirements for Prometheus

### DIFF
--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
+# Adds namespace to all resources.
+namespace: nnf-dm-system
+
 resources:
 - monitor.yaml

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
+    prometheus-app: rabbit-nnf
   name: controller-manager-metrics-monitor
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_client_clusterrole_binding.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-reader-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrole_binding.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,8 +47,15 @@ deploy)
         $KUSTOMIZE build $OVERLAY_DIR | kubectl apply -f -
         break
     done
+
+    # Deploy the ServiceMonitor resource if its CRD is found. The CRD would
+    # have been installed by a metrics service such as Prometheus.
+    if kubectl get crd servicemonitors.monitoring.coreos.com > /dev/null 2>&1; then
+        $KUSTOMIZE build config/prometheus | kubectl apply -f-
+    fi
     ;;
 undeploy)
+    $KUSTOMIZE build config/prometheus | kubectl delete --ignore-not-found -f-
     # When the DataMovementManager CRD gets deleted all related resource are also
     # removed, so the delete will always fail. We ignore all errors at our
     # own risk.


### PR DESCRIPTION
Add a label to the ServiceMonitor resource that will be common across all DWS and NNF repos so we easily tell Prometheus which ones it should select.

Copy the namespace value into config/prometheus so that part of config/ can be deployed on its own.

Add a ClusterRoleBinding that can be used by a metrics reader process to debug the metrics endpoing of the controller.  The ClusterRole is already being installed, and the ServiceAccount is already installed.

Update the deploy.sh script to determine whether or not the ServiceMonitor resource can be applied.