### PR TITLE
Gate NnfDataMovementManager.Status.Ready flag on daemonset ready

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/controllers",
+            "program": "${workspaceFolder}/internal/controller",
             "args": [
                 "-ginkgo.v",
                 "-ginkgo.progress",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231108192651-ab8d87963df0
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231108192651-ab8d87963df0 h1:p6AuBbayRXU8WeBLBXXIihmJaB8IDJe9GjcEMFzJn6o=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231108192651-ab8d87963df0/go.mod h1:YX9Q91wqtUmfZjU4KxSwZMDJGBzppiGEW4BpAVTIMAs=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171 h1:BOOPzud2+RPRGsqD9Ld4B2KgFJdRhXhee9SgsrrOvpw=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171 h1:BOOPzud2+RPRGsqD9Ld4B2KgFJdRhXhee9SgsrrOvpw=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5 h1:ngJNueL3HbFewXc4pf3mRFQfEKOk0q6eJcQ4Ir787ho=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
@@ -26,12 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 const (
-	// The required namespace for an NNF Data Movement operation. This is for system wide (lustre) data movement.
-	// Individual nodes may also perform data movement in which case they use the NNF Node Name as the namespace.
+	// The required namespace for an NNF Data Movement operation. This is for system wide (lustre)
+	// data movement.  Individual nodes may also perform data movement in which case they use the
+	// NNF Node Name as the namespace.
 	DataMovementNamespace = "nnf-dm-system"
 )
 

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovementmanager_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovementmanager_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -64,7 +64,8 @@ type NnfDataMovementManagerStatus struct {
 
 	// Ready indicates that the Data Movement Manager has achieved the desired readiness state
 	// and all managed resources are initialized.
-	Ready bool `json:"ready,omitempty"`
+	// +kubebuilder:default:=false
+	Ready bool `json:"ready"`
 }
 
 //+kubebuilder:object:root=true
@@ -81,6 +82,10 @@ type NnfDataMovementManager struct {
 	Status NnfDataMovementManagerStatus `json:"status,omitempty"`
 }
 
+func (m *NnfDataMovementManager) GetStatus() updater.Status[*NnfDataMovementManagerStatus] {
+	return &m.Status
+}
+
 //+kubebuilder:object:root=true
 
 // NnfDataMovementManagerList contains a list of NnfDataMovementManager
@@ -92,8 +97,4 @@ type NnfDataMovementManagerList struct {
 
 func init() {
 	SchemeBuilder.Register(&NnfDataMovementManager{}, &NnfDataMovementManagerList{})
-}
-
-func (m *NnfDataMovementManager) GetStatus() updater.Status[*NnfDataMovementManagerStatus] {
-	return &m.Status
 }

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovementmanager_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovementmanager_types.go
@@ -22,10 +22,16 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataWorkflowServices/dws/utils/updater"
 )
 
 const (
 	DataMovementWorkerLabel = "dm.cray.hpe.com/worker"
+
+	// The name of the expected Data Movement manager. This is to ensure Data Movement is ready in
+	// the DataIn/DataOut stages before attempting data movement operations.
+	DataMovementManagerName = "nnf-dm-manager-controller-manager"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -86,4 +92,8 @@ type NnfDataMovementManagerList struct {
 
 func init() {
 	SchemeBuilder.Register(&NnfDataMovementManager{}, &NnfDataMovementManagerList{})
+}
+
+func (m *NnfDataMovementManager) GetStatus() updater.Status[*NnfDataMovementManagerStatus] {
+	return &m.Status
 }

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementmanagers.yaml
@@ -7637,9 +7637,12 @@ spec:
               NnfDataMovementManager
             properties:
               ready:
+                default: false
                 description: Ready indicates that the Data Movement Manager has achieved
                   the desired readiness state and all managed resources are initialized.
                 type: boolean
+            required:
+            - ready
             type: object
         type: object
     served: true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231108192651-ab8d87963df0
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114145107-35f00d043171
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases


### PR DESCRIPTION

  * Don't signal ready until the nnf-dm-worker daemonset is update to date
    and ready
  * If there's an error, set ready to false
  * Added isDaemonSetReady() function to check on the status of the
    daemonset. This needs to happen as part of the main reconciler loop
    and when removing the finalizers.
  * Use the status updater to set the Ready flag.
  
  Signed-off-by: Blake Devcich <blake.devcich@hpe.com>