### PR TITLE
Added ability to use non-default profiles

### DIFF
--- a/config/dm_config/nnf-dm-config.yaml
+++ b/config/dm_config/nnf-dm-config.yaml
@@ -1,35 +1,41 @@
 # Each profile is capable of providing different configurations for data movement.
-# Note: For now, only the default profile is supported.
 profiles:
-
   # Default profile that is used for all data movement activity.
   default:
-      # The number of slots specified in the MPI hostfile. A value less than 1 disables the use
-      # of slots in the hostfile.
-      slots: 8
+    # The number of slots specified in the MPI hostfile. A value less than 1 disables the use
+    # of slots in the hostfile.
+    slots: 8
 
-      # The number of max_slots specified in the MPI hostfile. A value less than 1 disables the use
-      # of max_slots in the hostfile.
-      maxSlots: 0
+    # The number of max_slots specified in the MPI hostfile. A value less than 1 disables the use
+    # of max_slots in the hostfile.
+    maxSlots: 0
 
-      # The full command to execute data movement. $VARS are replaced by the nnf software. Available
-      # $VARS:
-      #   HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
-      #             slots/max_slots for each host. This hostfile is created at `/tmp/<dm-name>/hostfile`
-      #   UID: User ID that is inherited from the Workflow
-      #   GID: Group ID that is inherited from the Workflow
-      #   SRC: source for the data movement
-      #   DEST destination for the data movement
-      # default: command: ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST
-      command: ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST
+    # The full command to execute data movement. $VARS are replaced by the nnf software. Available
+    # $VARS:
+    #   HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
+    #             slots/max_slots for each host. This hostfile is created at `/tmp/<dm-name>/hostfile`
+    #   UID: User ID that is inherited from the Workflow
+    #   GID: Group ID that is inherited from the Workflow
+    #   SRC: source for the data movement
+    #   DEST destination for the data movement
+    # default: command: ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST
+    command: ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --uid $UID --gid $GID $SRC $DEST
 
-      # If true, enable the command's stdout to be saved in the log when the command completes
-      # successfully. On failure, the output is always logged.
-      logStdout: false
+    # If true, enable the command's stdout to be saved in the log when the command completes
+    # successfully. On failure, the output is always logged.
+    logStdout: false
 
-      # Similar to logStdout, store the command's stdout in Status.Message when the command
-      # completes successfully. On failure, the output is always stored.
-      storeStdout: false
+    # Similar to logStdout, store the command's stdout in Status.Message when the command
+    # completes successfully. On failure, the output is always stored.
+    storeStdout: false
+
+  # Same as default profile but tell dcp not to copy xattrs
+  no-xattr:
+    slots: 8
+    maxSlots: 0
+    command: ulimit -n 2048 && mpirun --allow-run-as-root --hostfile $HOSTFILE dcp --progress 1 --xattrs none --uid $UID --gid $GID $SRC $DEST
+    logStdout: false
+    storeStdout: false
 
 # NnfDataMovement resources have the ability to collect and store the progress percentage and the
 # last few lines of output in the CommandStatus field. This number is used for the interval to collect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231116180019-91601a97a3d2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5 h1:ngJNueL3HbFewXc4pf3mRFQfEKOk0q6eJcQ4Ir787ho=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440 h1:H1PJnKfnvWdaHYrT9QAF2FoFjTjDFBYIMacA4pLBL1I=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20231031201943-531116c1194e/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440 h1:H1PJnKfnvWdaHYrT9QAF2FoFjTjDFBYIMacA4pLBL1I=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231116180019-91601a97a3d2 h1:7E4SvAx78e8bvzWiP5532SoaTY84IXUx5fyJ14Y04B8=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231116180019-91601a97a3d2/go.mod h1:t0KypbCmssZzL9vhQFHLdauxHKgptJK1SbPJHjm+Baw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
@@ -31,6 +31,10 @@ const (
 	// data movement.  Individual nodes may also perform data movement in which case they use the
 	// NNF Node Name as the namespace.
 	DataMovementNamespace = "nnf-dm-system"
+
+	// The name of the default profile stored in the nnf-dm-config ConfigMap that is used to
+	// configure Data Movement.
+	DataMovementProfileDefault = "default"
 )
 
 // NnfDataMovementSpec defines the desired state of NnfDataMovement
@@ -57,6 +61,11 @@ type NnfDataMovementSpec struct {
 	// Set to true if the data movement operation should be canceled.
 	// +kubebuilder:default:=false
 	Cancel bool `json:"cancel,omitempty"`
+
+	// Profile specifies the name of profile in the nnf-dm-config ConfigMap to be used for
+	// configuring data movement. Defaults to the default profile.
+	// +kubebuilder:default:=default
+	Profile string `json:"profile,omitempty"`
 
 	// User defined configuration on how data movement should be performed. This overrides the
 	// configuration defined in the nnf-dm-config ConfigMap. These values are typically set by the

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovements.yaml
@@ -109,6 +109,12 @@ spec:
                   operation.
                 format: int32
                 type: integer
+              profile:
+                default: default
+                description: Profile specifies the name of profile in the nnf-dm-config
+                  ConfigMap to be used for configuring data movement. Defaults to
+                  the default profile.
+                type: string
               source:
                 description: Source describes the source of the data movement operation
                 properties:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231114204216-1a62f95d74d5
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231115183043-7345e20cf440
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20231116180019-91601a97a3d2
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases


### PR DESCRIPTION
* Added no-xattr profile to nnf-dm-config config map to run `dcp --xattrs none`
  * Having another profile in there makes it easier for int-test
* DM controller now looks retrieves the profile specified by dm.spec.profile

Copy Offload API does not yet support this

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
