### PR TITLE
Mark DMM as not ready when desired DS pods is 0

### DIFF
--- a/internal/controller/datamovementmanager_controller.go
+++ b/internal/controller/datamovementmanager_controller.go
@@ -504,8 +504,9 @@ func (r *NnfDataMovementManagerReconciler) isDaemonSetReady(ctx context.Context,
 		return false, err
 	}
 
+	// DS is not ready when the generations do not match, desired is 0 (e.g. no nnf nodes available), scheduled != desired, ready != desired
 	d := ds.Status.DesiredNumberScheduled
-	if ds.Status.ObservedGeneration != ds.ObjectMeta.Generation || ds.Status.UpdatedNumberScheduled != d || ds.Status.NumberReady != d {
+	if ds.Status.ObservedGeneration != ds.ObjectMeta.Generation || d < 1 || ds.Status.UpdatedNumberScheduled != d || ds.Status.NumberReady != d {
 		return false, nil
 	}
 


### PR DESCRIPTION
If the number of nnf-nodes is 0, then data movement is not ready to do
any work.

This is something I've seen here and then when messing with
undeploy/redeploys and global lustre.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
