### PR TITLE
Ensure destination path exists prior to data movement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,7 +56,7 @@
                 "-ginkgo.failFast",
             ],
             "env": {
-                "KUBEBUILDER_ASSETS": "${workspaceRoot}/bin/k8s/1.25.0-darwin-amd64",
+                "KUBEBUILDER_ASSETS": "${workspaceRoot}/bin/k8s/1.28.0-darwin-arm64",
                 "GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT": "10m",
                 "GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL": "500ms",
             },

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240304141437-90661aa48ecb
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240221214302-e7989177289a
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0
@@ -27,7 +27,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -73,7 +73,7 @@ require (
 )
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6
+	github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1
 	go.openly.dev/pointy v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d h1:rDuKtl+vziSoDjZbOgDNk8EBOeVIZZ+NVLrb7fxY6Bg=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d/go.mod h1:T48LZQlkkQbIg5m3uUOevNjnpqP2Tl92cIwYt0/CQTc=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240304141437-90661aa48ecb h1:XCuNn0g+HJM7L3bsMwrJWJ9gm8MT3cgakHC0ikMKWL8=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240304141437-90661aa48ecb/go.mod h1:T48LZQlkkQbIg5m3uUOevNjnpqP2Tl92cIwYt0/CQTc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6 h1:LYKIIoawsuo+1ByvQaIpgl8vZc2KrE0q7AE7t0YumrI=
-github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1 h1:BSVqA7mYIzb867DGukYIPjL2lsagvlrZ6xHBwC2VzsU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1/go.mod h1:vSTBLWbsFjMYxx+sjMDyZpMXLY9m5Bp73cjnmAL30WU=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d h1:AP1TgQlneYZT/AxkYFyvJp1j86+7MTYOoo3I1Zw3L2E=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240220213720-51597bca637d/go.mod h1:qBcz9p8sXm1qhDf8WUmhxTlD1NCMEjoAD7NoHbQvMiI=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f h1:aWtSSQLLk9mUZj94mowirQeVw9saf80gVe10X0rZe8o=
 github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240221214302-e7989177289a h1:m3lPHiWObITk+zp3GAuOeawkaMr+U4aKlHcblYnsP58=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240221214302-e7989177289a/go.mod h1:4kJuGEwS46EYIt24NmNweaMryYp8M6RabNc8Nd+GIBE=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d h1:rDuKtl+vziSoDjZbOgDNk8EBOeVIZZ+NVLrb7fxY6Bg=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d/go.mod h1:T48LZQlkkQbIg5m3uUOevNjnpqP2Tl92cIwYt0/CQTc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/systemconfiguration_types.go
+++ b/vendor/github.com/DataWorkflowServices/dws/api/v1alpha2/systemconfiguration_types.go
@@ -116,6 +116,7 @@ func init() {
 	SchemeBuilder.Register(&SystemConfiguration{}, &SystemConfigurationList{})
 }
 
+// Computes returns the names of the computes attached to Rabbit nodes
 func (in *SystemConfiguration) Computes() []*string {
 	// We expect that there can be a large number of compute nodes and we don't
 	// want to duplicate all of those names.
@@ -125,8 +126,7 @@ func (in *SystemConfiguration) Computes() []*string {
 	for i1 := range in.Spec.StorageNodes {
 		num += len(in.Spec.StorageNodes[i1].ComputesAccess)
 	}
-	// Add room for the external computes.
-	num += len(in.Spec.ExternalComputeNodes)
+
 	computes := make([]*string, num)
 	idx := 0
 	for i2 := range in.Spec.StorageNodes {
@@ -135,9 +135,18 @@ func (in *SystemConfiguration) Computes() []*string {
 			idx++
 		}
 	}
+	return computes
+}
+
+// ComputesExternal returns the names of the external compute nodes in the system
+func (in *SystemConfiguration) ComputesExternal() []*string {
+	num := len(in.Spec.ExternalComputeNodes)
+	computes := make([]*string, num)
+	idx := 0
+
 	// Add the external computes.
-	for i4 := range in.Spec.ExternalComputeNodes {
-		computes[idx] = &in.Spec.ExternalComputeNodes[i4].Name
+	for i := range in.Spec.ExternalComputeNodes {
+		computes[idx] = &in.Spec.ExternalComputeNodes[i].Name
 		idx++
 	}
 	return computes

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
@@ -21,7 +21,6 @@ package v1alpha1
 
 import (
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
-	"github.com/DataWorkflowServices/dws/utils/updater"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -203,10 +202,6 @@ type NnfDataMovement struct {
 
 	Spec   NnfDataMovementSpec   `json:"spec,omitempty"`
 	Status NnfDataMovementStatus `json:"status,omitempty"`
-}
-
-func (n *NnfDataMovement) GetStatus() updater.Status[*NnfDataMovementStatus] {
-	return &n.Status
 }
 
 //+kubebuilder:object:root=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnf_datamovement_types.go
@@ -21,6 +21,7 @@ package v1alpha1
 
 import (
 	dwsv1alpha2 "github.com/DataWorkflowServices/dws/api/v1alpha2"
+	"github.com/DataWorkflowServices/dws/utils/updater"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -202,6 +203,10 @@ type NnfDataMovement struct {
 
 	Spec   NnfDataMovementSpec   `json:"spec,omitempty"`
 	Status NnfDataMovementStatus `json:"status,omitempty"`
+}
+
+func (n *NnfDataMovement) GetStatus() updater.Status[*NnfDataMovementStatus] {
+	return &n.Status
 }
 
 //+kubebuilder:object:root=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/pkg/command/cmd.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/pkg/command/cmd.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+var log logr.Logger
+
+// Run command and grab the default timeout environment variable, if set
+func Run(args string, log logr.Logger) (string, error) {
+	return run(args, log, nil, nil)
+}
+
+// Run command as a specific UID/GID
+func RunAs(args string, log logr.Logger, uid, gid uint32) (string, error) {
+	return run(args, log, &uid, &gid)
+}
+
+// Run with a specific timeout
+func RunWithTimeout(args string, timeout int, log logr.Logger) (string, error) {
+	return runWithTimeout(args, timeout, log, nil, nil)
+}
+
+// Run command as a specific UID/GID with a specific timeout
+func RunAsWithTimeout(args string, timeout int, log logr.Logger, uid, gid *uint32) (string, error) {
+	return runWithTimeout(args, timeout, log, uid, gid)
+}
+
+func run(args string, log logr.Logger, uid, gid *uint32) (string, error) {
+	timeoutString, found := os.LookupEnv("NNF_COMMAND_TIMEOUT_SECONDS")
+	if found {
+		timeout, err := strconv.Atoi(timeoutString)
+		if err != nil {
+			return "", err
+		}
+
+		return runWithTimeout(args, timeout, log, uid, gid)
+	}
+
+	return runWithTimeout(args, 0, log, uid, gid)
+}
+
+func runWithTimeout(args string, timeout int, log logr.Logger, uid, gid *uint32) (string, error) {
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
+	var stdout, stderr bytes.Buffer
+	shellCmd := exec.CommandContext(ctx, "bash", "-c", args)
+	shellCmd.Stdout = &stdout
+	shellCmd.Stderr = &stderr
+
+	// If UID/GID are set, then run this command with those
+	if uid != nil && gid != nil {
+		shellCmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: *uid, Gid: *gid}}
+		log.V(1).Info("Command Run", "UID", uid, "GID", gid, "command", args)
+	} else {
+		log.V(1).Info("Command Run", "command", args)
+	}
+
+	err := shellCmd.Run()
+	if err != nil {
+		return stdout.String(), fmt.Errorf("command: %s - stderr: %s - stdout: %s - error: %w", args, stderr.String(), stdout.String(), err)
+	}
+
+	// Command success, return stdout
+	return stdout.String(), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240304141437-90661aa48ecb
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20240221183421-1a123a9274b6
+# github.com/DataWorkflowServices/dws v0.0.1-0.20240223212516-e29a8a3306e1
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/api/v1alpha2
 github.com/DataWorkflowServices/dws/utils/dwdparse
@@ -10,10 +10,11 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.0-20231010162453-a8168bb6a52f
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240221214302-e7989177289a
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240301200517-8266b0710b4d
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases
+github.com/NearNodeFlash/nnf-sos/pkg/command
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
To ensure that dcp behaves the same on each data movement, make sure the destination path exists before attempting data movement.

This also ensures that as long as the user provides a valid path with the correct permissions, dcp will have a safe place for the destination.

Path validation will need to be done upfront in nnf-sos and the nnf-dm daemon.