### PR TITLE
Only delete DMs that were created by the go client

### DIFF
--- a/daemons/compute/client-go/main.go
+++ b/daemons/compute/client-go/main.go
@@ -181,8 +181,9 @@ func main() {
 	// and couldn't recover the data movement request). The NNF Data Movement Workflow ensures that these requests are
 	// deleted.
 	if !*skipDelete {
-		// Use List to cleanup and delete requests
-		for _, uid := range listResponse.GetUids() {
+		// Delete each DM this client created
+		for _, resp := range responses {
+			uid := resp.GetUid()
 			log.Printf("Deleting request: %v", uid)
 
 			deleteResponse, err := deleteRequest(ctx, c, *workflow, *namespace, uid)


### PR DESCRIPTION
The existing loop was too aggressive - trying to delete every DM owned by the workflow. This was causing issues when multiple clients on multiple compute nodes were attempting to delete the same DMs.