### PR TITLE
nnf-dm daemon: Add workflow labels + check for PreRun Completed

### DIFF
--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -15,6 +15,13 @@ rules:
 - apiGroups:
   - dataworkflowservices.github.io
   resources:
+  - workflows
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - dataworkflowservices.github.io
+  resources:
   - clientmounts
   verbs:
   - get


### PR DESCRIPTION
Add the appropriate labels on the data movement resource to tie it to the workflow. This is to ensure that data movement resources are deleted when the workflow is. Otherwise, it's up to the client to manually remove these data movement resources and they can be left around.

To do this, we must go and get the workflow resource itself. Add a check to make sure the workflow exists and ensure that it is in the appropriate state (PreRun completed).

This check was happening implicitly when attempting to find a clientmount resource that matches the source path. Now, a better error message is returned if the workflow can not be found (can not find workflow vs can not find clientmount).