### PR TITLE
Use ubi8 for rpm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ RPM_TARGET ?= x86_64
 build-daemon-rpm: RPM_VERSION ?= $(shell ./git-version-gen | sed -e 's/\-.*//')
 build-daemon-rpm: $(RPMBIN)
 build-daemon-rpm: fmt vet ## Build standalone nnf-dm binary and its rpm
-	${CONTAINER_TOOL} build --platform=$(RPM_PLATFORM) --build-arg="RPMTARGET=$(RPM_TARGET)" --build-arg="RPMVERSION=$(RPM_VERSION)" --output=type=local,dest=$(RPMBIN) -f Dockerfile.rpmbuild .
+	${CONTAINER_TOOL} build --platform=$(RPM_PLATFORM) --build-arg="RPMTARGET=$(RPM_TARGET)" --build-arg="RPMVERSION=$(RPM_VERSION)" --output=type=local,dest=$(RPMBIN) -f daemons/compute/server/Dockerfile.rpmbuild .
 
 .PHONY: build-daemon
 build-daemon: RPM_VERSION ?= $(shell ./git-version-gen)

--- a/daemons/compute/server/Dockerfile.rpmbuild
+++ b/daemons/compute/server/Dockerfile.rpmbuild
@@ -46,7 +46,7 @@ RUN mkdir /artifacts && \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-X '$PACKAGE_VERSION.version=$RPMVERSION'" -a -o /artifacts/nnf-dm daemons/compute/server/main.go && \
     tar -czf /artifacts/nnf-dm-$RPMVERSION.tar.gz --transform 's,^,nnf-dm-'$RPMVERSION'/,' .
 
-FROM --platform=$BUILDPLATFORM centos:8 AS rpmbuilder
+FROM --platform=$BUILDPLATFORM redhat/ubi8-minimal AS rpmbuilder
 
 ARG RPMVERSION
 ARG RPMTARGET
@@ -54,8 +54,7 @@ ARG RPMTARGET
 # The mkdirs in /root/rpmbuild would normally be done by rpmdev-setuptree.
 # However, we're trying to cut the run time and that drags in a lot of
 # dependencies.
-RUN dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos && \
-    dnf -y install rpm-build && \
+RUN microdnf -y --enablerepo=ubi-8-appstream-rpms install rpm-build && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES
 
 WORKDIR /workspace


### PR DESCRIPTION
The centos:8 image's rpm repo has changed, so while I'm revisiting this I'll switch to ubi8.

Move the Dockerfile down to the daemon, with its spec file.