### PR TITLE
Do rpm build on all pushes

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -4,10 +4,7 @@
 
 
 name: RPM Build
-on:
-  push:
-    branches:
-      - '*'
+on: push
 
 jobs:
   rpm_build:


### PR DESCRIPTION
It wasn't doing a push on merge to the releases/v0 branch. However, other workflows that simply have "on: push" were building on that merge. So, let's try that.