### PR TITLE
Add version labels to release manifest items

### DIFF
--- a/hack/make-kustomization2.sh
+++ b/hack/make-kustomization2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -21,10 +21,10 @@ set -e
 
 OVERLAY_DIR=$1
 OVERLAY=$2
-IMAGE_TAG_BASE_1=$3
-TAG_1=$4
-IMAGE_TAG_BASE_2=$5
-TAG_2=$6
+IMAGE_TAG_BASE_NNF_DM=$3
+TAG_NNF_DM=$4
+IMAGE_TAG_BASE_NNF_MFU=$5
+TAG_NNF_MFU=$6
 
 if [[ ! -d $OVERLAY_DIR ]]
 then
@@ -35,12 +35,27 @@ cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
 resources:
 - ../$OVERLAY
 
+commonLabels:
+  app.kubernetes.io/version: "$TAG_NNF_DM"
+  app.kubernetes.io/component: nnf-dm
+EOF
+
+if [[ -n $NNF_VERSION ]]
+then
+    cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
+  app.kubernetes.io/nnf-version: "$NNF_VERSION"
+  app.kubernetes.io/part-of: nnf
+EOF
+fi
+
+cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: $IMAGE_TAG_BASE_1
-  newTag: $TAG_1
-- name: $IMAGE_TAG_BASE_2
-  newTag: $TAG_2
+- name: $IMAGE_TAG_BASE_NNF_DM
+  newTag: $TAG_NNF_DM
+- name: $IMAGE_TAG_BASE_NNF_MFU
+  newTag: $TAG_NNF_MFU
 EOF
 


### PR DESCRIPTION
Add component/version labels to each resource in the manifest. If run locally the labels will be:

  app.kubernetes.io/component: nnf-dm
  app.kubernetes.io/version: <git-version-gen>

If run from nnf-deploy's "make manifests" the labels will be:

  app.kubernetes.io/component: nnf-dm
  app.kubernetes.io/version: <nnf-dm's git-version-gen>
  app.kubernetes.io/part-of: nnf
  app.kubernetes.io/nnf-version: <nnf-deploy's git-version-gen>