### PR TITLE
Optional DM mkdir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141008-b67847b5c8fd
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240816013414-a2246392cd0a
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf/go.mod h1:N5X1obpl0mBI0VoCJdQhv7cFXOC6g3VlXj712qWj0JE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5 h1:7eT5mOVSNwtacIcGhzMAsi8EVbeS4zk9QwThG2f0GHE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240816013414-a2246392cd0a h1:h08LssHEqjca6mWLHjEPwoozQ01VAslvmUI2aUzTQIM=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240816013414-a2246392cd0a/go.mod h1:uJvjwkSLrPk4A/13U/E4vnO8R+utDE/lGclsKVp/88s=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c h1:VAjgBFhkJr+Y7qp6AjWaVCJuUz9QiuJ2tGTUSFsuSis=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c/go.mod h1:uJvjwkSLrPk4A/13U/E4vnO8R+utDE/lGclsKVp/88s=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240709160956-40dcbac0aadf/go.mod h1:N5X1obpl0mBI0VoCJdQhv7cFXOC6g3VlXj712qWj0JE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5 h1:7eT5mOVSNwtacIcGhzMAsi8EVbeS4zk9QwThG2f0GHE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c h1:VAjgBFhkJr+Y7qp6AjWaVCJuUz9QiuJ2tGTUSFsuSis=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c/go.mod h1:uJvjwkSLrPk4A/13U/E4vnO8R+utDE/lGclsKVp/88s=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141008-b67847b5c8fd h1:RxeF/TnVqg8kiLpqAv3HoVnW/DOL5E2szKhXLkQ+d3c=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141008-b67847b5c8fd/go.mod h1:uJvjwkSLrPk4A/13U/E4vnO8R+utDE/lGclsKVp/88s=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
@@ -75,6 +75,13 @@ type NnfDataMovementProfileData struct {
 	// +kubebuilder:default:=5
 	// +kubebuilder:validation:Minimum:=0
 	ProgressIntervalSeconds int `json:"progressIntervalSeconds,omitempty"`
+
+	// CreateDestDir will ensure that the destination directory exists before performing data
+	// movement.  This will cause a number of stat commends to determine the source and destination
+	// file types, so that the correct pathing for the destination can be determined. Then, a mkdir
+	// is issued.
+	// +kubebuilder:default:=true
+	CreateDestDir bool `json:"createDestDir"`
 }
 
 // +kubebuilder:object:root=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
@@ -77,7 +77,7 @@ type NnfDataMovementProfileData struct {
 	ProgressIntervalSeconds int `json:"progressIntervalSeconds,omitempty"`
 
 	// CreateDestDir will ensure that the destination directory exists before performing data
-	// movement.  This will cause a number of stat commends to determine the source and destination
+	// movement. This will cause a number of stat commands to determine the source and destination
 	// file types, so that the correct pathing for the destination can be determined. Then, a mkdir
 	// is issued.
 	// +kubebuilder:default:=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -52,6 +52,14 @@ spec:
                     SRC: source for the data movement
                     DEST destination for the data movement
                 type: string
+              createDestDir:
+                default: true
+                description: |-
+                  CreateDestDir will ensure that the destination directory exists before performing data
+                  movement.  This will cause a number of stat commends to determine the source and destination
+                  file types, so that the correct pathing for the destination can be determined. Then, a mkdir
+                  is issued.
+                type: boolean
               default:
                 default: false
                 description: Default is true if this instance is the default resource
@@ -98,6 +106,7 @@ spec:
                 type: boolean
             required:
             - command
+            - createDestDir
             - maxSlots
             - slots
             type: object

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -56,7 +56,7 @@ spec:
                 default: true
                 description: |-
                   CreateDestDir will ensure that the destination directory exists before performing data
-                  movement.  This will cause a number of stat commends to determine the source and destination
+                  movement. This will cause a number of stat commands to determine the source and destination
                   file types, so that the correct pathing for the destination can be determined. Then, a mkdir
                   is issued.
                 type: boolean

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141008-b67847b5c8fd
 ## explicit; go 1.21
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240708183336-34d1295977f5
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240816013414-a2246392cd0a
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240819183331-7ebf170c8f2c
 ## explicit; go 1.21
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases


### PR DESCRIPTION
For things like SCR that are using the Copy Offload API, the destination
can easily be created by the client software. SCR guarantees this.

Using profiles, allow the destination prep (mkdir to ensure dest exists)
to be skipped.

This way, copy_in/copy_out can still ensure the dest exists while
disabling this behavior for SCR.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
