### PR TITLE
Add StatCommand to NnfDataMovementProfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240826132702-ccad8ac920b3
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141947-f61076751e0f
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d/go.mod h1:N5X1obpl0mBI0VoCJdQhv7cFXOC6g3VlXj712qWj0JE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4 h1:cxUkRTnynEvCLbYL+d/FVyITLODO/goscivJLq5kipY=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141947-f61076751e0f h1:TzN+pKBC5jmLri5TEArWCzki4NIkfpxRTyQKev0oRKQ=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141947-f61076751e0f/go.mod h1:uTPaHauR9qBPXN9HxWadxK4mrgmuQqBAEboDQI4Okms=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5 h1:XW7QMgMtr0jYPrSrTqVQXfqvID+nKhIupL47ywxrG4M=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5/go.mod h1:mVnVYQlWGQCReGo7M3HliyES3xPqjtiSeA6VBu9+YRg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20240820214524-99d5da17471d/go.mod h1:N5X1obpl0mBI0VoCJdQhv7cFXOC6g3VlXj712qWj0JE=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4 h1:cxUkRTnynEvCLbYL+d/FVyITLODO/goscivJLq5kipY=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4/go.mod h1:oxdwMqfttOF9dabJhqrWlirCnMk8/8eyLMwl+hducjk=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5 h1:XW7QMgMtr0jYPrSrTqVQXfqvID+nKhIupL47ywxrG4M=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5/go.mod h1:mVnVYQlWGQCReGo7M3HliyES3xPqjtiSeA6VBu9+YRg=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240826132702-ccad8ac920b3 h1:Z3Rridh8oZPfonnWcwjOjtZtCgnP6l7F4GOkxh0r24c=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240826132702-ccad8ac920b3/go.mod h1:t/xEK8ND+sTy3gvYEiCH6OOFxhQdRZgDVZQCHRbB+XU=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/controller/datamovement_controller.go
+++ b/internal/controller/datamovement_controller.go
@@ -270,12 +270,12 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	log.Info("MPI Hostfile preview", "first line", peekMpiHostfile(mpiHostfile))
 
 	// Prepare Destination Directory
-	if err = r.prepareDestination(ctx, profile, mpiHostfile, dm, log); err != nil {
+	if err = r.prepareDestination(ctx, profile, dm, mpiHostfile, log); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Build command
-	cmdArgs, err := buildDMCommand(ctx, profile, mpiHostfile, dm)
+	cmdArgs, err := buildDMCommand(profile, mpiHostfile, dm, log)
 	if err != nil {
 		return ctrl.Result{}, dwsv1alpha2.NewResourceError("could not create data movement command").WithError(err).WithMajor()
 	}
@@ -551,8 +551,7 @@ func (r *DataMovementReconciler) getDMProfile(ctx context.Context, dm *nnfv1alph
 	return profile, nil
 }
 
-func buildDMCommand(ctx context.Context, profile *nnfv1alpha1.NnfDataMovementProfile, hostfile string, dm *nnfv1alpha1.NnfDataMovement) ([]string, error) {
-	log := log.FromContext(ctx)
+func buildDMCommand(profile *nnfv1alpha1.NnfDataMovementProfile, hostfile string, dm *nnfv1alpha1.NnfDataMovement, log logr.Logger) ([]string, error) {
 	userConfig := dm.Spec.UserConfig != nil
 
 	// If Dryrun is enabled, just use the "true" command
@@ -594,43 +593,49 @@ func buildDMCommand(ctx context.Context, profile *nnfv1alpha1.NnfDataMovementPro
 	return strings.Split(cmd, " "), nil
 }
 
-func (r *DataMovementReconciler) prepareDestination(ctx context.Context, profile *nnfv1alpha1.NnfDataMovementProfile, mpiHostfile string, dm *nnfv1alpha1.NnfDataMovement, log logr.Logger) error {
+func buildStatCommand(uid, gid uint32, cmd, hostfile, path string) string {
+	cmd = strings.ReplaceAll(cmd, "$HOSTFILE", hostfile)
+	cmd = strings.ReplaceAll(cmd, "$UID", fmt.Sprintf("%d", uid))
+	cmd = strings.ReplaceAll(cmd, "$GID", fmt.Sprintf("%d", gid))
+	cmd = strings.ReplaceAll(cmd, "$PATH", path)
+
+	return cmd
+}
+
+func (r *DataMovementReconciler) prepareDestination(ctx context.Context, profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, mpiHostfile string, log logr.Logger) error {
 	// These functions interact with the filesystem, so they can't run in the test env
-	// Also, if the profile disables destination creation, skip it
-	if isTestEnv() || !profile.Data.CreateDestDir {
-		return nil
-	}
-
-	// Determine the destination directory based on the source and path
-	log.Info("Determining destination directory based on source/dest file types")
-	destDir, err := getDestinationDir(dm, mpiHostfile, log)
-	if err != nil {
-		return dwsv1alpha2.NewResourceError("could not determine source type").WithError(err).WithFatal()
-	}
-
-	// See if an index mount directory on the destination is required
-	log.Info("Determining if index mount directory is required")
-	indexMount, err := r.checkIndexMountDir(ctx, dm)
-	if err != nil {
-		return dwsv1alpha2.NewResourceError("could not determine index mount directory").WithError(err).WithFatal()
-	}
-
-	// Account for index mount directory on the destDir and the dm dest path
-	// This updates the destination on dm
-	if indexMount != "" {
-		log.Info("Index mount directory is required", "indexMountdir", indexMount)
-		d, err := handleIndexMountDir(destDir, indexMount, dm, mpiHostfile, log)
+	if !isTestEnv() {
+		// Determine the destination directory based on the source and path
+		log.Info("Determining destination directory based on source/dest file types")
+		destDir, err := getDestinationDir(profile, dm, mpiHostfile, log)
 		if err != nil {
-			return dwsv1alpha2.NewResourceError("could not handle index mount directory").WithError(err).WithFatal()
+			return dwsv1alpha2.NewResourceError("could not determine source type").WithError(err).WithFatal()
 		}
-		destDir = d
-		log.Info("Updated destination for index mount directory", "destDir", destDir, "dm.Spec.Destination.Path", dm.Spec.Destination.Path)
-	}
 
-	// Create the destination directory
-	log.Info("Creating destination directory", "destinationDir", destDir, "indexMountDir", indexMount)
-	if err := createDestinationDir(destDir, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log); err != nil {
-		return dwsv1alpha2.NewResourceError("could not create destination directory").WithError(err).WithFatal()
+		// See if an index mount directory on the destination is required
+		log.Info("Determining if index mount directory is required")
+		indexMount, err := r.checkIndexMountDir(ctx, dm)
+		if err != nil {
+			return dwsv1alpha2.NewResourceError("could not determine index mount directory").WithError(err).WithFatal()
+		}
+
+		// Account for index mount directory on the destDir and the dm dest path
+		// This updates the destination on dm
+		if indexMount != "" {
+			log.Info("Index mount directory is required", "indexMountdir", indexMount)
+			d, err := handleIndexMountDir(profile, dm, destDir, indexMount, mpiHostfile, log)
+			if err != nil {
+				return dwsv1alpha2.NewResourceError("could not handle index mount directory").WithError(err).WithFatal()
+			}
+			destDir = d
+			log.Info("Updated destination for index mount directory", "destDir", destDir, "dm.Spec.Destination.Path", dm.Spec.Destination.Path)
+		}
+
+		// Create the destination directory
+		log.Info("Creating destination directory", "destinationDir", destDir, "indexMountDir", indexMount)
+		if err := createDestinationDir(profile, dm, destDir, mpiHostfile, log); err != nil {
+			return dwsv1alpha2.NewResourceError("could not create destination directory").WithError(err).WithFatal()
+		}
 	}
 
 	log.Info("Destination prepared", "dm.Spec.Destination", dm.Spec.Destination)
@@ -707,7 +712,7 @@ func extractIndexMountDir(path, namespace string) (string, error) {
 
 // Given a destination directory and index mount directory, apply the necessary changes to the
 // destination directory and the DM's destination path to account for index mount directories
-func handleIndexMountDir(destDir, indexMount string, dm *nnfv1alpha1.NnfDataMovement, mpiHostfile string, log logr.Logger) (string, error) {
+func handleIndexMountDir(profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, destDir, indexMount, mpiHostfile string, log logr.Logger) (string, error) {
 
 	// For cases where the root directory (e.g. $DW_JOB_my_workflow) is supplied, the path will end
 	// in the index mount directory without a trailing slash. If that's the case, there's nothing
@@ -723,11 +728,11 @@ func handleIndexMountDir(destDir, indexMount string, dm *nnfv1alpha1.NnfDataMove
 	dmDest := idxMntDir
 
 	// Get the source to see if it's a file
-	srcIsFile, err := isSourceAFile(dm.Spec.Source.Path, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log)
+	srcIsFile, err := isSourceAFile(profile, dm, mpiHostfile, log)
 	if err != nil {
 		return "", err
 	}
-	destIsFile := isDestAFile(dm.Spec.Destination.Path, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log)
+	destIsFile := isDestAFile(profile, dm, mpiHostfile, log)
 	log.Info("Checking source and dest types", "srcIsFile", srcIsFile, "destIsFile", destIsFile)
 
 	// Account for file-file
@@ -749,21 +754,19 @@ func handleIndexMountDir(destDir, indexMount string, dm *nnfv1alpha1.NnfDataMove
 
 // Determine the directory path to create based on the source and destination.
 // Returns the mkdir directory and error.
-func getDestinationDir(dm *nnfv1alpha1.NnfDataMovement, mpiHostfile string, log logr.Logger) (string, error) {
+func getDestinationDir(profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, mpiHostfile string, log logr.Logger) (string, error) {
 	// Default to using the full path of dest
-	src := dm.Spec.Source.Path
-	dest := dm.Spec.Destination.Path
-	destDir := dest
+	destDir := dm.Spec.Destination.Path
 
-	srcIsFile, err := isSourceAFile(src, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log)
+	srcIsFile, err := isSourceAFile(profile, dm, mpiHostfile, log)
 	if err != nil {
 		return "", err
 	}
 
 	// Account for file-file data movement - we don't want the full path
 	// ex: /path/to/a/file -> /path/to/a
-	if srcIsFile && isDestAFile(dest, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log) {
-		destDir = filepath.Dir(dest)
+	if srcIsFile && isDestAFile(profile, dm, mpiHostfile, log) {
+		destDir = filepath.Dir(dm.Spec.Destination.Path)
 	}
 
 	// We know it's a directory, so we don't care about the trailing slash
@@ -771,63 +774,50 @@ func getDestinationDir(dm *nnfv1alpha1.NnfDataMovement, mpiHostfile string, log 
 }
 
 // Use mpirun to run stat on a file as a given UID/GID by using `setpriv`
-func mpiStat(path string, uid, gid uint32, mpiHostfile string, log logr.Logger) (string, error) {
-	// Use setpriv to stat the path with the specified UID/GID. Only run it on 1 host (ie. -n 1)
-	cmd := fmt.Sprintf("mpirun --allow-run-as-root -n 1 --hostfile %s -- setpriv --euid %d --egid %d --clear-groups stat --cached never -c '%%F' %s",
-		mpiHostfile, uid, gid, path)
+func mpiStat(profile *nnfv1alpha1.NnfDataMovementProfile, path string, uid, gid uint32, mpiHostfile string, log logr.Logger) (string, error) {
+	cmd := buildStatCommand(uid, gid, profile.Data.StatCommand, mpiHostfile, path)
 
 	output, err := command.Run(cmd, log)
 	if err != nil {
 		return output, fmt.Errorf("could not stat path ('%s'): %w", path, err)
 	}
-	log.Info("mpiStat", "path", path, "output", output)
+	log.Info("mpiStat", "command", cmd, "path", path, "output", output)
 
 	return output, nil
 }
 
-// Use mpirun to check if a file exists
-func mpiExists(path string, uid, gid uint32, mpiHostfile string, log logr.Logger) (bool, error) {
-	_, err := mpiStat(path, uid, gid, mpiHostfile, log)
-	if err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "no such file or directory") {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
-}
-
 // Use mpirun to determine if a given path is a directory
-func mpiIsDir(path string, uid, gid uint32, mpiHostfile string, log logr.Logger) (bool, error) {
-	output, err := mpiStat(path, uid, gid, mpiHostfile, log)
+func mpiIsDir(profile *nnfv1alpha1.NnfDataMovementProfile, path string, uid, gid uint32, mpiHostfile string, log logr.Logger) (bool, error) {
+	output, err := mpiStat(profile, path, uid, gid, mpiHostfile, log)
 	if err != nil {
 		return false, err
 	}
 
 	if strings.Contains(strings.ToLower(output), "directory") {
-		log.Info("mpiIsDir", "directory", true)
+		log.Info("mpiIsDir", "path", path, "directory", true)
 		return true, nil
-	} else {
-		log.Info("mpiIsDir", "directory", true)
+	} else if strings.Contains(strings.ToLower(output), "file") {
+		log.Info("mpiIsDir", "path", path, "directory", false)
 		return false, nil
+	} else {
+		return false, fmt.Errorf("could not determine file type of path ('%s'): %s", path, output)
 	}
 }
 
 // Check to see if the source path is a file. The source must exist and will result in error if it
 // does not. Do not use mpi in the test environment.
-func isSourceAFile(src string, uid, gid uint32, mpiHostFile string, log logr.Logger) (bool, error) {
+func isSourceAFile(profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, mpiHostFile string, log logr.Logger) (bool, error) {
 	var isDir bool
 	var err error
 
 	if isTestEnv() {
-		sf, err := os.Stat(src)
+		sf, err := os.Stat(dm.Spec.Source.Path)
 		if err != nil {
 			return false, fmt.Errorf("source file does not exist: %w", err)
 		}
 		isDir = sf.IsDir()
 	} else {
-		isDir, err = mpiIsDir(src, uid, gid, mpiHostFile, log)
+		isDir, err = mpiIsDir(profile, dm.Spec.Source.Path, dm.Spec.UserId, dm.Spec.GroupId, mpiHostFile, log)
 		if err != nil {
 			return false, err
 		}
@@ -839,9 +829,10 @@ func isSourceAFile(src string, uid, gid uint32, mpiHostFile string, log logr.Log
 // Check to see if the destination path is a file. If it exists, use stat to determine if it is a
 // file or a directory. If it doesn't exist, check for a trailing slash and make an assumption based
 // on that.
-func isDestAFile(dest string, uid, gid uint32, mpiHostFile string, log logr.Logger) bool {
+func isDestAFile(profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, mpiHostFile string, log logr.Logger) bool {
 	isFile := false
 	exists := true
+	dest := dm.Spec.Destination.Path
 
 	// Attempt to the get the destination file. The error is not important since an assumption can
 	// be made by checking if there is a trailing slash.
@@ -853,7 +844,7 @@ func isDestAFile(dest string, uid, gid uint32, mpiHostFile string, log logr.Logg
 			exists = false
 		}
 	} else {
-		isDir, err := mpiIsDir(dest, uid, gid, mpiHostFile, log)
+		isDir, err := mpiIsDir(profile, dest, dm.Spec.UserId, dm.Spec.GroupId, mpiHostFile, log)
 		if err == nil { // file exists, so use mpiIsDir() result
 			isFile = !isDir
 		} else {
@@ -870,17 +861,32 @@ func isDestAFile(dest string, uid, gid uint32, mpiHostFile string, log logr.Logg
 	return isFile
 }
 
-func createDestinationDir(dest string, uid, gid uint32, mpiHostfile string, log logr.Logger) error {
+func createDestinationDir(profile *nnfv1alpha1.NnfDataMovementProfile, dm *nnfv1alpha1.NnfDataMovement, dest, mpiHostfile string, log logr.Logger) error {
+
+	// Use mpirun to check if a file exists
+	mpiExists := func() (bool, error) {
+		_, err := mpiStat(profile, dest, dm.Spec.UserId, dm.Spec.GroupId, mpiHostfile, log)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "no such file or directory") {
+				return false, nil
+			}
+			return false, err
+		}
+
+		return true, nil
+	}
+
 	// Don't do anything if it already exists
-	if exists, err := mpiExists(dest, uid, gid, mpiHostfile, log); err != nil {
+	if exists, err := mpiExists(); err != nil {
 		return err
 	} else if exists {
 		return nil
 	}
 
+	// TODO mkdir command?
 	// Use setpriv to create the directory with the specified UID/GID
 	cmd := fmt.Sprintf("mpirun --allow-run-as-root --hostfile %s -- setpriv --euid %d --egid %d --clear-groups mkdir -p %s",
-		mpiHostfile, uid, gid, dest)
+		mpiHostfile, dm.Spec.UserId, dm.Spec.GroupId, dest)
 	output, err := command.Run(cmd, log)
 	if err != nil {
 		return fmt.Errorf("data movement mkdir failed ('%s'): %w output: %s", cmd, err, output)

--- a/internal/controller/datamovement_controller_test.go
+++ b/internal/controller/datamovement_controller_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // This is dumped into a temporary file and then ran as a bash script.
@@ -800,7 +801,7 @@ var _ = Describe("Data Movement Test", func() {
 						"mpirun --allow-run-as-root --hostfile /tmp/hostfile dcp --progress 1 --uid %d --gid %d --extra opts %s %s",
 						expectedUid, expectedGid, srcPath, destPath)
 
-					cmd, err := buildDMCommand(context.TODO(), &profile, "/tmp/hostfile", &dm)
+					cmd, err := buildDMCommand(&profile, "/tmp/hostfile", &dm, log.FromContext(context.TODO()))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(strings.Join(cmd, " ")).Should(MatchRegexp(expectedCmdRegex))
 				})
@@ -902,7 +903,9 @@ var _ = Describe("Data Movement Test", func() {
 						},
 					}
 
-					destDir, err := getDestinationDir(dm, "", logr.Logger{})
+					dmProfile := &nnfv1alpha1.NnfDataMovementProfile{}
+
+					destDir, err := getDestinationDir(dmProfile, dm, "", logr.Logger{})
 					destDir = strings.Replace(destDir, tmpDir, "", -1) // remove tmpdir from the path
 					Expect(err).ToNot(HaveOccurred())
 					Expect(destDir).To(Equal(expected))
@@ -1008,7 +1011,9 @@ var _ = Describe("Data Movement Test", func() {
 						},
 					}
 
-					newDestDir, err := handleIndexMountDir(destDir, idxMount, dm, "", logr.Logger{})
+					dmProfile := &nnfv1alpha1.NnfDataMovementProfile{}
+
+					newDestDir, err := handleIndexMountDir(dmProfile, dm, destDir, idxMount, "", logr.Logger{})
 					Expect(err).ToNot((HaveOccurred()))
 
 					// Remove any tmpDir paths before verifying

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfcontainerprofile_webhook.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfcontainerprofile_webhook.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -36,12 +36,15 @@ import (
 // log is for logging in this package.
 var nnfcontainerprofilelog = logf.Log.WithName("nnfcontainerprofile")
 
+// SetupWebhookWithManager will setup the manager to manage the webhooks
 func (r *NnfContainerProfile) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }
 
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 //+kubebuilder:webhook:path=/validate-nnf-cray-hpe-com-v1alpha1-nnfcontainerprofile,mutating=false,failurePolicy=fail,sideEffects=None,groups=nnf.cray.hpe.com,resources=nnfcontainerprofiles,verbs=create;update,versions=v1alpha1,name=vnnfcontainerprofile.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &NnfContainerProfile{}

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_types.go
@@ -82,6 +82,18 @@ type NnfDataMovementProfileData struct {
 	// is issued.
 	// +kubebuilder:default:=true
 	CreateDestDir bool `json:"createDestDir"`
+
+	// If CreateDestDir is true, then use StatCommand to perform the stat commands.
+	// Use setpriv to stat the path with the specified UID/GID.
+	// Available $VARS:
+	//   HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
+	//             slots/max_slots for each host. This hostfile is created at
+	//             `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
+	//   UID: User ID that is inherited from the Workflow
+	//   GID: Group ID that is inherited from the Workflow
+	//   PATH: Path to stat
+	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- setpriv --euid $UID --egid $GID --clear-groups stat --cached never -c '%F' $PATH"
+	StatCommand string `json:"statCommand"`
 }
 
 // +kubebuilder:object:root=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_webhook.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfdatamovementprofile_webhook.go
@@ -41,6 +41,8 @@ func (r *NnfDataMovementProfile) SetupWebhookWithManager(mgr ctrl.Manager) error
 		Complete()
 }
 
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-nnf-cray-hpe-com-v1alpha1-nnfdatamovementprofile,mutating=false,failurePolicy=fail,sideEffects=None,groups=nnf.cray.hpe.com,resources=nnfdatamovementprofiles,verbs=create;update,versions=v1alpha1,name=vnnfdatamovementprofile.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &NnfDataMovementProfile{}

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfstorageprofile_webhook.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha1/nnfstorageprofile_webhook.go
@@ -35,12 +35,15 @@ import (
 // log is for logging in this package.
 var nnfstorageprofilelog = logf.Log.WithName("nnfstorageprofile")
 
+// SetupWebhookWithManager will setup the manager to manage the webhooks
 func (r *NnfStorageProfile) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }
 
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 //+kubebuilder:webhook:path=/validate-nnf-cray-hpe-com-v1alpha1-nnfstorageprofile,mutating=false,failurePolicy=fail,sideEffects=None,groups=nnf.cray.hpe.com,resources=nnfstorageprofiles,verbs=create;update,versions=v1alpha1,name=vnnfstorageprofile.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &NnfStorageProfile{}

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -98,6 +98,21 @@ spec:
                   slots in the hostfile.
                 minimum: 0
                 type: integer
+              statCommand:
+                default: mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE --
+                  setpriv --euid $UID --egid $GID --clear-groups stat --cached never
+                  -c '%F' $PATH
+                description: |-
+                  If CreateDestDir is true, then use StatCommand to perform the stat commands.
+                  Use setpriv to stat the path with the specified UID/GID.
+                  Available $VARS:
+                    HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
+                              slots/max_slots for each host. This hostfile is created at
+                              `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
+                    UID: User ID that is inherited from the Workflow
+                    GID: Group ID that is inherited from the Workflow
+                    PATH: Path to stat
+                type: string
               storeStdout:
                 default: false
                 description: |-
@@ -109,6 +124,7 @@ spec:
             - createDestDir
             - maxSlots
             - slots
+            - statCommand
             type: object
           kind:
             description: |-

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240821141947-f61076751e0f
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5
 ## explicit; go 1.21
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.1-0.20240820195316-cb407b151cb4
 ## explicit; go 1.19
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240823192835-a28ec6899ab5
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20240826132702-ccad8ac920b3
 ## explicit; go 1.21
 github.com/NearNodeFlash/nnf-sos/api/v1alpha1
 github.com/NearNodeFlash/nnf-sos/config/crd/bases


### PR DESCRIPTION
The current implementation of the stat commands that are used in data
movement destination prep are hard-coded. This allows the command to be
customized in the profile.

When I first implemented this, I tried to keep the profile and dm
resource out of the function calls as much as possible and just pass
down the info needed. This change is to the contrary of that since we
now need to pass the statCommand all the way down to the bottom of the
call stack when the stat actually takes place.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
