### PR TITLE
Added ConfigMap for nnf-dm-worker's sshd_config

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- worker-sshd-config.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -82,6 +82,10 @@ spec:
             privileged: true
             capabilities:
               add: ['SETUID', 'SETGID', 'MKNOD']
+          volumeMounts:
+            - name:  worker-config
+              mountPath: /etc/ssh/sshd_config
+              subPath: sshd_config
         - name: manager
           command:
             - /manager
@@ -94,3 +98,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+      volumes:
+        - name: worker-config
+          configMap:
+            name: nnf-dm-worker-config

--- a/config/manager/worker-sshd-config.yaml
+++ b/config/manager/worker-sshd-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-config
+data:
+  sshd_config: |
+    Include /etc/ssh/sshd_config.d/*.conf
+    Port 2222
+    StrictModes no
+    MaxSessions 4096
+    MaxStartups 4096
+    ChallengeResponseAuthentication no
+    UsePAM yes
+    X11Forwarding yes
+    PrintMotd no
+    AcceptEnv LANG LC_*
+    Subsystem sftp /usr/lib/openssh/sftp-server


### PR DESCRIPTION
There was no way to adjust MaxStartups without spinning a new image.
This allows for a site-specific configuration, if needed.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
