### PR TITLE
Add support for nnf-dm-debug image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ env:
   DO_TEST: true
 
 jobs:
-  build:
+  production:
     runs-on: ubuntu-latest
 
     steps:
@@ -61,7 +61,7 @@ jobs:
           # For PR event or merge event, tag example: 1.0.1.12-5667
           type=raw,value=${{ env.VERSION_TAG }}
           # For PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
-          type=raw,value=${{ env.SHA_TAG }}          
+          type=raw,value=${{ env.SHA_TAG }}
           # For push to semver tag, tag example: 1.0.2
           # This also sets 'latest'.
           type=semver,pattern={{version}}
@@ -95,10 +95,99 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
+        target: production
+        tags: ${{ steps.meta.outputs.tags }}
+
+  debug:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Build context"
+      run: |
+        echo "ref is ${{ github.ref }}"
+        echo "ref_type is ${{ github.ref_type }}"
+
+    - name: "Checkout repository"
+      id: checkout_repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: "Lowercase repository name for docker build"
+      id: lowercase-repository-name
+      run: echo "REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: "Set tags for main/master"
+      id: set_tags
+      run: |
+        echo "VERSION_TAG=$(./git-version-gen | grep -v UNKNOWN)" >> ${GITHUB_ENV}
+        echo "TEST_TAG=$(git rev-parse HEAD)-test" >> ${GITHUB_ENV}
+        echo "SHA_TAG=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
+        echo "${GITHUB_ENV}:"
+        cat ${GITHUB_ENV}
+      shell: bash
+
+    - name: "Verify auto-generated files"
+      run: |
+          make manifests generate
+          if [[ $(git status -s | wc -l) -gt 0 ]]; then \
+              git status; exit 1; \
+          fi
+
+    - name: "Docker metadata"
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/${{ env.REPO_NAME }}-debug
+        tags: |
+          # For merge to master branch, tag example: 'master'
+          type=ref,event=branch
+          # For PR event, tag example: 'pr-3'
+          type=ref,event=pr
+          # For PR event or merge event, tag example: 1.0.1.12-5667
+          type=raw,value=${{ env.VERSION_TAG }}
+          # For PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
+          type=raw,value=${{ env.SHA_TAG }}
+          # For push to semver tag, tag example: 1.0.2
+          # This also sets 'latest'.
+          type=semver,pattern={{version}}
+          # For push to semver tag, tag example: 1.0
+          type=semver,pattern={{major}}.{{minor}}
+
+    - name: "Docker login"
+      id: docker_login
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Build the test Docker image"
+      id: docker_build_test_target
+      if: ${{ env.DO_TEST == 'true' }}
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        target: ${{ env.TEST_TARGET }}
+        tags: ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
+
+    - name: "Run the Docker image unit tests"
+      id: docker_test
+      if: ${{ env.DO_TEST == 'true' }}
+      run: docker run ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
+
+    - name: "Build the debug Docker image"
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        target: debug
         tags: ${{ steps.meta.outputs.tags }}
 
   create_release:
-    needs: build
+    needs: production
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This uses the nnf-mfu-debug image which has mpifileutils/dcp debug
builds installed.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
