### PR TITLE
mpirun hostfiles: make sure each host is only listed once

### DIFF
--- a/internal/controller/datamovement_controller.go
+++ b/internal/controller/datamovement_controller.go
@@ -954,7 +954,15 @@ func writeMpiHostfile(dmName string, hosts []string, slots, maxSlots int) (strin
 	// node0 slots=2 max_slots=20
 	// node1 slots=2 max_slots=20
 	// https://www.open-mpi.org/faq/?category=running#mpirun-hostfile
+	unique_hosts := map[string]int{}
 	for _, host := range hosts {
+		// hostfiles cannot list a host more than once - this can happen when there are multiple
+		// OSTs on a single rabbit. Move on if a host is already present.
+		if _, found := unique_hosts[host]; found {
+			continue
+		}
+		unique_hosts[host] = 1
+
 		if _, err := f.WriteString(host); err != nil {
 			return "", err
 		}

--- a/internal/controller/datamovement_controller_test.go
+++ b/internal/controller/datamovement_controller_test.go
@@ -708,7 +708,6 @@ var _ = Describe("Data Movement Test", func() {
 	Describe("Unit Tests (without Reconciler)", func() {
 
 		Context("MPI hostfile creation", func() {
-			hosts := []string{"node1", "node2"}
 			DescribeTable("setting hosts, slots, and maxSlots",
 				func(hosts []string, slots, maxSlots int, expected string) {
 					hostfilePath, err := writeMpiHostfile("my-dm", hosts, slots, maxSlots)
@@ -720,10 +719,13 @@ var _ = Describe("Data Movement Test", func() {
 					Expect(err).To(BeNil())
 					Expect(string(contents)).To(Equal(expected))
 				},
-				Entry("with no slots or max_slots", hosts, 0, 0, "node1\nnode2\n"),
-				Entry("with only slots", hosts, 4, 0, "node1 slots=4\nnode2 slots=4\n"),
-				Entry("with only max_slots", hosts, 0, 4, "node1 max_slots=4\nnode2 max_slots=4\n"),
-				Entry("with both slots and max_slots", hosts, 4, 4, "node1 slots=4 max_slots=4\nnode2 slots=4 max_slots=4\n"),
+				Entry("with no slots or max_slots", []string{"node1", "node2"}, 0, 0, "node1\nnode2\n"),
+				Entry("with only slots", []string{"node1", "node2"}, 4, 0, "node1 slots=4\nnode2 slots=4\n"),
+				Entry("with only max_slots", []string{"node1", "node2"}, 0, 4, "node1 max_slots=4\nnode2 max_slots=4\n"),
+				Entry("with both slots and max_slots", []string{"node1", "node2"}, 4, 4, "node1 slots=4 max_slots=4\nnode2 slots=4 max_slots=4\n"),
+				Entry("with duplicate hosts (1 dup host)", []string{"node1", "node1"}, 2, 4, "node1 slots=2 max_slots=4\n"),
+				Entry("with duplicate hosts (2 dup hosts)", []string{"node1", "node1", "node2", "node2"}, 2, 4, "node1 slots=2 max_slots=4\nnode2 slots=2 max_slots=4\n"),
+				Entry("with duplicate hosts (1 dup host, no slots)", []string{"node1", "node1", "node1", "node2"}, 0, 0, "node1\nnode2\n"),
 			)
 		})
 


### PR DESCRIPTION
Performing lustre-to-lustre datamovement when there are multiple
OSTs on a single rabbit leads to a hostfile that contains the same host
(rabbit) multiple times. This throws an error with mpirun.

This fix ensures that each host is only listed once in the hostfile.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
