### PR TITLE
Propagate the ENVIRONMENT env variable to sub-deployment and daemonset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,9 @@ jobs:
     - name: "Verify auto-generated files"
       run: |
           make manifests generate
+          git status
           if [[ $(git status -s | wc -l) -gt 0 ]]; then \
-              git status; exit 1; \
+              exit 1; \
           fi
 
     - name: "Docker metadata"

--- a/config/dp0/kustomization.yaml
+++ b/config/dp0/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../default
+
+patches:
+# Arguments for the controller manager that are specific to dp0
+- path: manager_environment_deploy_patch.yaml

--- a/config/dp0/manager_environment_deploy_patch.yaml
+++ b/config/dp0/manager_environment_deploy_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager-controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: ENVIRONMENT
+          value: "production"

--- a/config/kind/kustomization.yaml
+++ b/config/kind/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../default
+
+patches:
+# Arguments for the controller manager that are specific to kind
+- path: manager_environment_deploy_patch.yaml

--- a/config/kind/manager_environment_deploy_patch.yaml
+++ b/config/kind/manager_environment_deploy_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager-controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: ENVIRONMENT
+          value: "kind"

--- a/internal/controller/datamovementmanager_controller.go
+++ b/internal/controller/datamovementmanager_controller.go
@@ -27,6 +27,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
 
 	"golang.org/x/crypto/ssh"
 
@@ -459,6 +460,12 @@ func (r *NnfDataMovementManagerReconciler) createOrUpdateDaemonSetIfNecessary(ct
 		podSpec := &podTemplateSpec.Spec
 		podSpec.NodeSelector = manager.Spec.Selector.MatchLabels
 		podSpec.Subdomain = serviceName
+
+		container, err := findManagerContainer(podSpec)
+		if err != nil {
+			return err
+		}
+		container.Env = append(container.Env, corev1.EnvVar{Name: "ENVIRONMENT", Value: os.Getenv("ENVIRONMENT")})
 
 		setupSSHAuthVolumes(manager, podSpec)
 


### PR DESCRIPTION
Let the main controller propagate its ENVIRONMENT env variable to the data movement deployment and daemonset that it creates.