### PR TITLE
Trim the progress lines from the dcp output

### DIFF
--- a/daemons/copy-offload/pkg/driver/driver.go
+++ b/daemons/copy-offload/pkg/driver/driver.go
@@ -444,30 +444,33 @@ func runit(ctxCancel context.Context, contextDelete func(), cmd *exec.Cmd, cmdSt
 		//dm.Status.State = nnfv1alpha4.DataMovementConditionTypeFinished
 		//dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonSuccess
 
+		// Grab the output and trim it to remove the progress bloat
+		output := helpers.TrimDcpProgressFromOutput(combinedOutBuf.String())
+
 		// On cancellation or failure, log the output. On failure, also store the output in the
 		// Status.Message. When successful, check the profile/UserConfig config options to log
 		// and/or store the output.
 		if errors.Is(ctxCancel.Err(), context.Canceled) {
-			log.Info("Data movement operation cancelled", "output", combinedOutBuf.String())
+			log.Info("Data movement operation cancelled", "output", output)
 			//dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonCancelled
 		} else if err != nil {
-			log.Error(err, "Data movement operation failed", "output", combinedOutBuf.String())
+			log.Error(err, "Data movement operation failed", "output", output)
 			//dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonFailed
-			//dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), combinedOutBuf.String())
-			//resourceErr := dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("data movement operation failed: %s", combinedOutBuf.String()).WithFatal()
+			//dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), output)
+			//resourceErr := dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("data movement operation failed: %s", output).WithFatal()
 			//dm.Status.SetResourceErrorAndLog(resourceErr, log)
 		} else {
 			log.Info("Data movement operation completed", "cmdStatus", cmdStatus)
 
 			// Profile or DM request has enabled stdout logging
 			//if profile.Data.LogStdout || (dm.Spec.UserConfig != nil && dm.Spec.UserConfig.LogStdout) {
-			//	log.Info("Data movement operation output", "output", combinedOutBuf.String())
+			//	log.Info("Data movement operation output", "output", output)
 			//}
-			log.Info("Data movement operation output", "output", combinedOutBuf.String())
+			log.Info("Data movement operation output", "output", output)
 
 			//// Profile or DM request has enabled storing stdout
 			//if profile.Data.StoreStdout || (dm.Spec.UserConfig != nil && dm.Spec.UserConfig.StoreStdout) {
-			//	dm.Status.Message = combinedOutBuf.String()
+			//	dm.Status.Message = output
 			//}
 		}
 

--- a/internal/controller/datamovement_controller.go
+++ b/internal/controller/datamovement_controller.go
@@ -335,29 +335,32 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		dm.Status.State = nnfv1alpha4.DataMovementConditionTypeFinished
 		dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonSuccess
 
+		// Grab the output and trim it to remove the progress bloat
+		output := TrimDcpProgressFromOutput(combinedOutBuf.String())
+
 		// On cancellation or failure, log the output. On failure, also store the output in the
 		// Status.Message. When successful, check the profile/UserConfig config options to log
 		// and/or store the output.
 		if errors.Is(ctxCancel.Err(), context.Canceled) {
-			log.Info("Data movement operation cancelled", "output", combinedOutBuf.String())
+			log.Info("Data movement operation cancelled", "output", output)
 			dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonCancelled
 		} else if err != nil {
-			log.Error(err, "Data movement operation failed", "output", combinedOutBuf.String())
+			log.Error(err, "Data movement operation failed", "output", output)
 			dm.Status.Status = nnfv1alpha4.DataMovementConditionReasonFailed
-			dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), combinedOutBuf.String())
-			resourceErr := dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("data movement operation failed: %s", combinedOutBuf.String()).WithFatal()
+			dm.Status.Message = fmt.Sprintf("%s: %s", err.Error(), output)
+			resourceErr := dwsv1alpha2.NewResourceError("").WithError(err).WithUserMessage("data movement operation failed: %s", output).WithFatal()
 			dm.Status.SetResourceErrorAndLog(resourceErr, log)
 		} else {
 			log.Info("Data movement operation completed", "cmdStatus", cmdStatus)
 
 			// Profile or DM request has enabled stdout logging
 			if profile.Data.LogStdout || (dm.Spec.UserConfig != nil && dm.Spec.UserConfig.LogStdout) {
-				log.Info("Data movement operation output", "output", combinedOutBuf.String())
+				log.Info("Data movement operation output", "output", output)
 			}
 
 			// Profile or DM request has enabled storing stdout
 			if profile.Data.StoreStdout || (dm.Spec.UserConfig != nil && dm.Spec.UserConfig.StoreStdout) {
-				dm.Status.Message = combinedOutBuf.String()
+				dm.Status.Message = output
 			}
 		}
 


### PR DESCRIPTION
This can cause problems in k8s when the output has many lines of dcp
progress output. The DM resource can get too big when trying to update
its status because the dcp output log is saturated with progress lines.
In this case, k8s will reject the update to DM resource.

This keeps the first and last line of output and inserts a snippet to
indicate that the progress was removed:

```
[2025-01-21T09:28:31] Walked 2 items in 0.001 secs (2315.244 items/sec) ...
[2025-01-21T09:28:31] Walked 2 items in 0.001 seconds (2102.366 items/sec)
[2025-01-21T09:28:31] Copying to /lus/global/blake/tmpdr/rabbit-node-1-0
[2025-01-21T09:28:31] Items: 2
[2025-01-21T09:28:31]   Directories: 1
[2025-01-21T09:2:31[]   Files: 1
[2025-01-21T09:28:31]   Links: 0
[2025-01-21T09:28:31] Data: 93.132 GiB (93.132 GiB per file)
[2025-01-21T09:28:31] Creating 1 directories
[2025-01-21T09:28:31] Original directory exists, skip the creation: `/lus/global/blake/tmpdr/rabbit-node-1-0' (errno=17 File exists)
[2025-01-21T09:28:31] Creating 1 files.
[2025-01-21T09:28:31] Copying data.
[2025-01-21T09:28:32] Copied 276.000 MiB (0%) in 1.528 secs (180.642 MiB/s) 526 secs left ...
...
<snipped dcp progress output>
...
[2025-01-21T09:42:41] Copied 93.132 GiB (100%) in 850.608 secs (112.117 MiB/s) done
[2025-01-21T09:42:41] Copy data: 93.132 GiB (100000000000 bytes)
[2025-01-21T09:42:41] Copy rate: 112.117 MiB/s (100000000000 bytes in 850.608 seconds)
[2025-01-21T09:42:41] Syncing data to disk.
[2025-01-21T09:42:41] Sync completed in 0.001 seconds.
[2025-01-21T09:42:41] Fixing permissions.
[2025-01-21T09:42:41] Updated 2 items in 0.003 seconds (798.217 items/sec)\
n[2025-01-21T09:42:41] Syncing directory updates to disk.
[2025-01-21T09:42:41] Sync completed in 0.001 seconds.
[2025-01-21T09:42:41] Started: Jan-21-2025,09:28:31
[2025-01-21T09:42:41] Completed: Jan-21-2025,09:42:41
[2025-01-21T09:42:41] Seconds: 850.614
[2025-01-21T0:42:41[] Items: 2
[2025-01-21T09:42:41]   Directories: 1
[2025-01-21T09:42:41]   Files: 1
[2025-01-21T09:42:41]   Links: 0
[2025-01-2109:42:41[] Data: 93.132 GiB (100000000000 bytes)
[2025-01-21T09:42:41] Rate: 112.116 MiB/s (100000000000 bytes in 850.614 seconds)
```

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
