### PR TITLE
Let copy-offload server_test generate its own test tokens/keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,15 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 FAILFAST ?= no
+TESTDIRS ?= internal daemons/copy-offload/pkg/server
 test: manifests generate fmt vet envtest ## Run tests.
 	if [[ "${FAILFAST}" == yes ]]; then \
 		failfast="-ginkgo.fail-fast"; \
 	fi; \
 	set -o errexit; \
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test -v ./... -coverprofile cover.out -ginkgo.v $$failfast
+	for subdir in ${TESTDIRS}; do \
+		KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test -v ./$$subdir/... -coverprofile cover-$$(basename $$subdir.out) -ginkgo.v $$failfast; \
+	done
 
 container-unit-test: VERSION ?= $(shell cat .version)
 container-unit-test: .version ## Run tests inside a container image

--- a/daemons/copy-offload/pkg/driver/driver.go
+++ b/daemons/copy-offload/pkg/driver/driver.go
@@ -102,12 +102,12 @@ func (r *DriverRequest) Create(ctx context.Context, dmreq DMRequest) (*nnfv1alph
 
 	wf := types.NamespacedName{Name: dmreq.WorkflowName, Namespace: dmreq.WorkflowNamespace}
 	if err := drvr.Client.Get(ctx, wf, workflow); err != nil {
-		crLog.Error(err, "Unable to get workflow")
+		crLog.Info("Unable to get workflow: %v", err)
 		return nil, err
 	}
 	if workflow.Status.State != dwsv1alpha2.StatePreRun || workflow.Status.Status != "Completed" {
 		err := fmt.Errorf("workflow must be in '%s' state and 'Completed' status", dwsv1alpha2.StatePreRun)
-		crLog.Error(err, "Invalid state")
+		crLog.Info("Workflow is in an invalid state: %v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Let copy-offload's server_test.go generate its own test tokens and keys.

Change some Error messages to Info where we don't need function stacks in the log files.
