### PR TITLE
Support per-Workflow tokens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,11 +288,14 @@ jobs:
       if: ${{ env.DO_TEST == 'true' && !env.ACT }}
       run: docker run ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
 
-    - name: "Install libcurl"
+    - name: "Install libcurl and shellcheck"
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y libcurl4-openssl-dev
+        sudo apt-get install -y libcurl4-openssl-dev shellcheck
  
+    - name: "Do shellcheck"
+      run: shellcheck tools/*.sh daemons/copy-offload-testing/e2e-mocked.sh
+
     - name: "Build lib-copy-offload"
       run: make -C ./daemons/lib-copy-offload libcopyoffload.a
 

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ edit-image: .version
 deploy: kustomize edit-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	./deploy.sh deploy $(KUSTOMIZE) config/begin
 	./deploy.sh deploy $(KUSTOMIZE) config/begin-examples
-	./tools/mk-copy-offload-secrets.sh
+	./tools/mk-usercontainer-secrets.sh
 
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	./deploy.sh undeploy $(KUSTOMIZE) config/$(OVERLAY)

--- a/config/examples/copyoffload-containerprofile.yaml
+++ b/config/examples/copyoffload-containerprofile.yaml
@@ -18,27 +18,17 @@ data:
         command:
           - /nnf-copy-offload
           - --cert
-          - /etc/copy-offload-tls/tls.crt
+          - $(TLS_CERT_PATH)
           - --cakey
-          - /etc/copy-offload-tls/tls.key
+          - $(TLS_KEY_PATH)
           - --tokenkey
-          - /etc/copy-offload-token/token.key
+          - $(TOKEN_KEY_PATH)
           - --addr
           - :$(NNF_CONTAINER_PORTS)
-        volumeMounts:
-          - name: copy-offload-tls
-            mountPath: /etc/copy-offload-tls
-            readOnly: true
-          - name: copy-offload-token
-            mountPath: /etc/copy-offload-token
-            readOnly: true
-    volumes:
-      - name: copy-offload-tls
-        secret:
-          secretName: nnf-dm-copy-offload-server-tls
-      - name: copy-offload-token
-        secret:
-          secretName: nnf-dm-copy-offload-server-token
-    serviceAccount: nnf-dm-copy-offload
+    # This ServiceAccount is used by the nnf-dm-copy-offload server to talk to
+    # the Kubernetes API server. This is ServiceAccount and its Role are
+    # defined in config/copy-offload.
+    # Normal user containers should not require Kubernetes API server privilege
+    # and should not have a service account.
     serviceAccountName: nnf-dm-copy-offload
   retryLimit: 2

--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -29,6 +29,10 @@ PROTO="http"
 CERTDIR=daemons/copy-offload-testing/certs
 SKIP_SAN=1 ./tools/gen_certs.sh $CERTDIR || exit 1
 
+TOKEN_KEY=$CERTDIR/token_key.pem
+JWT=$CERTDIR/token
+go run ./daemons/copy-offload-testing/make-jwt/make-jwt.go -tokenkey "$TOKEN_KEY" -token "$JWT"
+
 SRVR_CMD="./bin/nnf-copy-offload -addr $SRVR -mock ${SKIP_TOKEN:+-skip-token} ${SKIP_TLS:+-skip-tls}"
 CURL_APIVER_HDR="Accepts-version: 1.0"
 CA_KEY="$CERTDIR/ca/private/ca_key.pem"
@@ -51,11 +55,11 @@ if [[ -z $SKIP_TLS ]]; then
 fi
 if [[ -z $SKIP_TOKEN ]]; then
     SRVR_WANTS_KEY=1
-    TOKEN=$(<"$CERTDIR/client/token")
-    CURL_BEARER_TOKEN_HDR="Authorization: Bearer $TOKEN"
-    CO_TLS_ARGS="$CO_TLS_ARGS -t $CERTDIR/client/token"
+    DW_WORKFLOW_TOKEN=$(<"$JWT")
+    export DW_WORKFLOW_TOKEN
+    CURL_BEARER_TOKEN_HDR="Authorization: Bearer $DW_WORKFLOW_TOKEN"
 
-    token_key_file="$CERTDIR/ca/private/token_key.pem"
+    token_key_file="$TOKEN_KEY"
     SRVR_CMD_TOKEN_ARGS="-tokenkey $token_key_file"
 fi
 if [[ -n $SRVR_WANTS_KEY ]]; then

--- a/daemons/copy-offload-testing/make-jwt/make-jwt.go
+++ b/daemons/copy-offload-testing/make-jwt/make-jwt.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func createKeyForTokens() ([]byte, []byte, error) {
+	keyType := "EC PRIVATE KEY"
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return []byte{}, []byte{}, fmt.Errorf("failure from GenerateKey: %w", err)
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return []byte{}, []byte{}, fmt.Errorf("failure from MarshalPKCS8PrivateKey: %w", err)
+	}
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: keyType, Bytes: privBytes})
+	if pemKey == nil {
+		return []byte{}, []byte{}, errors.New("unable to PEM-encode signing key for token")
+	}
+	return privBytes, pemKey, nil
+}
+
+func createTokenFromKey(key []byte, method jwt.SigningMethod) (string, error) {
+	token := jwt.NewWithClaims(method,
+		jwt.MapClaims{
+			"sub": "user-container",
+			"iat": time.Now().Unix(),
+		})
+
+	tokenString, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("failure from SignedString: %w", err)
+	}
+	return tokenString, nil
+}
+
+func verifyToken(tokenString string, key []byte, method jwt.SigningMethod) error {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if token.Method.Alg() != method.Alg() {
+			return nil, errors.New("token verification failed: unexpected signing method for token")
+		}
+		return key, nil
+	})
+	if err != nil {
+		return fmt.Errorf("token verification failed: parse failed: %w", err)
+	}
+	if !token.Valid {
+		return errors.New("token verification failed: invalid token")
+	}
+	return nil
+}
+
+func main() {
+
+	tokenKeyFile := flag.String("tokenkey", "token_key.pem", "Output filel for the token key in PEM form.")
+	tokenFile := flag.String("token", "token", "Output file for the token.")
+	flag.Parse()
+
+	privKey, pemKey, err := createKeyForTokens()
+	if err != nil {
+		fmt.Printf("unable to create a signing key: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	signingMethod := jwt.SigningMethodHS256
+	tokenString, err := createTokenFromKey(privKey, signingMethod)
+	if err != nil {
+		fmt.Printf("unable to create token: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	err = verifyToken(tokenString, privKey, signingMethod)
+	if err != nil {
+		fmt.Printf("verify failed: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*tokenKeyFile, pemKey, 0600); err != nil {
+		fmt.Printf("unable to write file %s: %s\n", *tokenKeyFile, err.Error())
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*tokenFile, []byte(tokenString), 0600); err != nil {
+		fmt.Printf("unable to write file %s: %s\n", *tokenFile, err.Error())
+		os.Exit(1)
+	}
+
+	// Read the key and token from their files and verify that we can still
+	// make sense of them.
+
+	inKey, err := os.ReadFile(*tokenKeyFile)
+	if err != nil {
+		fmt.Printf("unable to read back the key file: %s\n", err.Error())
+		os.Exit(1)
+	}
+	keyBlock, _ := pem.Decode(inKey)
+	if !bytes.Equal(privKey, keyBlock.Bytes) {
+		fmt.Printf("key block does not match private key\n")
+		os.Exit(1)
+	}
+
+	tokenStr2, err := os.ReadFile(*tokenFile)
+	if err != nil {
+		fmt.Printf("unable to read back the token: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	err = verifyToken(string(tokenStr2), keyBlock.Bytes, signingMethod)
+	if err != nil {
+		fmt.Printf("verify 2 failed: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/daemons/copy-offload/pkg/server/server.go
+++ b/daemons/copy-offload/pkg/server/server.go
@@ -36,25 +36,25 @@ import (
 )
 
 type UserHttp struct {
-	Log    logr.Logger
-	Drvr   *driver.Driver
-	InTest bool
-	Mock   bool
-	DerKey string
+	Log      logr.Logger
+	Drvr     *driver.Driver
+	InTest   bool
+	Mock     bool
+	KeyBytes []byte
 }
 
 // The signing algorithm that we expect was used when signing the JWT.
-const jwtSigningAlgorithm = "HS256"
+var jwtSigningAlgorithm = jwt.SigningMethodHS256
 
 func (user *UserHttp) verifyToken(tokenString string) error {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if token.Method.Alg() != jwtSigningAlgorithm {
+		if token.Method.Alg() != jwtSigningAlgorithm.Name {
 			return nil, errors.New("unexpected signing method")
 		}
-		return []byte(user.DerKey), nil
+		return user.KeyBytes, nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("token parse failed: %w", err)
 	}
 	if !token.Valid {
 		return fmt.Errorf("invalid token")
@@ -64,7 +64,7 @@ func (user *UserHttp) verifyToken(tokenString string) error {
 
 func (user *UserHttp) validateMessage(w http.ResponseWriter, req *http.Request) string {
 	// Validate the bearer token, if the server is using one.
-	if user.DerKey != "" {
+	if len(user.KeyBytes) > 0 {
 		authHeader := req.Header.Get("Authorization")
 		if authHeader == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -26,6 +26,9 @@
 
 #define COPY_OFFLOAD_MSG_SIZE CURL_ERROR_SIZE * 2
 
+// The name of the environment variable that will contain the workflow's token.
+#define WORKFLOW_TOKEN_ENV "DW_WORKFLOW_TOKEN"
+
 struct copy_offload_s {
     CURL *curl;
     int skip_tls;
@@ -54,6 +57,9 @@ COPY_OFFLOAD *copy_offload_init();
  * for the handle.
  * This will enable mTLS when @clientcert and @key are non-NULL, otherwise it will enable TLS.
  * If @skip_tls is set, then TLS/mTLS will not be enabled.
+ * The token is normally taken from the DW_WORKFLOW_TOKEN environment variable,
+ * if it exists. If @token_path is supplied then it overrides the DW_WORKFLOW_TOKEN
+ * variable. If neither is found then no token is used.
  * Returns 0 on success.
  * On failure, returns 1 and places the error message in @offload->err_message. 
  */

--- a/tools/mk-usercontainer-secrets.sh
+++ b/tools/mk-usercontainer-secrets.sh
@@ -23,12 +23,10 @@ set -o pipefail
 SRVR_HOST="$1"
 SRVR_HOST=${SRVR_HOST:=localhost}
 
-SERVER_SECRET_TLS=nnf-dm-copy-offload-server-tls
-SERVER_SECRET_TOKEN=nnf-dm-copy-offload-server-token
-CLIENT_SECRET_TLS=nnf-dm-copy-offload-client-tls
-CLIENT_SECRET_TOKEN=nnf-dm-copy-offload-client-token
-if kubectl get secret "$SERVER_SECRET_TLS" "$SERVER_SECRET_TOKEN" "$CLIENT_SECRET_TLS" "$CLIENT_SECRET_TOKEN" 2> /dev/null; then
-    echo "The copy-offload secrets already exist in the cluster."
+SERVER_SECRET_TLS=nnf-dm-usercontainer-server-tls
+CLIENT_SECRET_TLS=nnf-dm-usercontainer-client-tls
+if kubectl get secret "$SERVER_SECRET_TLS" "$CLIENT_SECRET_TLS" 2> /dev/null; then
+    echo "The user-container secrets already exist in the cluster."
     exit 0
 fi
 
@@ -38,13 +36,7 @@ CERTDIR=certs
 KEY=$CERTDIR/ca/private/ca_key.pem
 SERVER_CERT=$CERTDIR/server/server_cert.pem
 
-TOKEN_KEY=$CERTDIR/ca/private/token_key.pem
-TOKEN=$CERTDIR/client/token
-
 kubectl create secret tls $SERVER_SECRET_TLS --cert $SERVER_CERT --key $KEY
 # Use an opaque secret for the client's TLS cert because we don't want to
 # give the key to the client.
 kubectl create secret generic $CLIENT_SECRET_TLS --from-file "tls.crt=$SERVER_CERT"
-
-kubectl create secret generic $CLIENT_SECRET_TOKEN --from-file "token=$TOKEN"
-kubectl create secret generic $SERVER_SECRET_TOKEN --from-file "token.key=$TOKEN_KEY"


### PR DESCRIPTION
Update the example copyoffload-containerprofile.yaml to no longer explicitly mount the Secrets. This is now handled by nnf-sos when it creates the Deployment for the user-container. Use environment variables for the path names to the cert&key and token signing key. The environment variables will be added to the Deployment by nnf-sos as well.

Rename tools/mk-copy-offload-secrets.sh to tools/mk-usercontainer-secrets.sh to show that this cert is available for any user container. Also no longer create the token secret here, because this is now handled by nnf-sos. Remove the token generation pieces from tools/gen_certs.sh since this is now handled by nnf-sos.

Change libcopyoffload to expect the token to be in an environment variable named DW_WORKFLOW_TOKEN. Allow this to be overridden by specifying a file that has the token. Update e2e-mocked.sh to use a DW_WORKFLOW_TOKEN environment variable to pass the token to the tester tool. Add a library that e2e-mocked can use to create the token signing key and token for its own purposes.

Change the copy-offload server to always wrangle the token signing key in binary form from a PEM block.