### PR TITLE
Use $SETPRIV in mkdir/stat command when necessary

### DIFF
--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -310,11 +310,7 @@ int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_
     curl_easy_setopt(offload->curl, CURLOPT_URL, urlbuf);
 
     if (profile_name == NULL) {
-        // We cannot use the default DM profile in k8s because it has setpriv commands to change
-        // from root to a non-root user. Those setpriv commands will fail in the copyoffload
-        // container since it is running as non-root. Therefore, we need to use the
-        // copy-offload-default profile and not the k8s default.
-        profile_name = "copy-offload-default";
+        profile_name = "";
     }
 
     if (dry_run) {

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20250221171407-1a51721c0739
+	github.com/DataWorkflowServices/dws v0.0.1-0.20250224211524-95e559ed4fa8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17
-	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250219193635-3e6c6b39d0e0 // indirect
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250221193225-b496a821842d
+	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c // indirect
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/prometheus/client_golang v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20250224211524-95e559ed4fa8
 	github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17
 	github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c // indirect
-	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693
+	github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250304162904-aa2ddc2de8f9
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/DataWorkflowServices/dws v0.0.1-0.20250221171407-1a51721c0739 h1:QpU3oUwqVI3yC38Ck+BH9bGl8hmoXOvEw8gk30k9l3U=
-github.com/DataWorkflowServices/dws v0.0.1-0.20250221171407-1a51721c0739/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250224211524-95e559ed4fa8 h1:plfxAo/J9942dSPju40X3JzvhxhcrBowk/DVmZ3WswE=
+github.com/DataWorkflowServices/dws v0.0.1-0.20250224211524-95e559ed4fa8/go.mod h1:i9v4K2d64a9uyd9ZazOJ85RWzVQjIgHWXkLo895KDAE=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17 h1:xYLLW3fMEKauujqkmspeWoyWhEEu+capOKUPePo4IuU=
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17/go.mod h1:H9GBWOmFp9BGGBWDVZk0pvPWzL6jUKkieVsIIoPlzMs=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250219193635-3e6c6b39d0e0 h1:5arAC1ZW6QRZsv4Sowhno3EeYtFTnYc/4Ody08shDDY=
-github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250219193635-3e6c6b39d0e0/go.mod h1:lx13ustzE/+39fLECky+CFKkAV8GYlX9eaI6IGmHQkY=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250221193225-b496a821842d h1:/xwEmSqkLBY8q0VFtPAesvwnHZB/1qj6CXt5SAb3MZ8=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250221193225-b496a821842d/go.mod h1:vaj4EtPkZMC8twMaPshfn1UyDpiVwQht0iXPPYX9Ewk=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c h1:YR/0Cd4QGDluZ0UwDzhJxBHy4eDhBjKFQSEP7LsEjsY=
+github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c/go.mod h1:lx13ustzE/+39fLECky+CFKkAV8GYlX9eaI6IGmHQkY=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693 h1:83wvr6Z/+wiY9QVTkAlFdva2MF46so1NwDHSLMJpsG0=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693/go.mod h1:9cjTZO4mYyk6BuPANVhOveyDCLYDnLagpdT+eAqhON8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17
 github.com/NearNodeFlash/lustre-fs-operator v0.0.1-0.20250219194350-45aad5cbbe17/go.mod h1:H9GBWOmFp9BGGBWDVZk0pvPWzL6jUKkieVsIIoPlzMs=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c h1:YR/0Cd4QGDluZ0UwDzhJxBHy4eDhBjKFQSEP7LsEjsY=
 github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c/go.mod h1:lx13ustzE/+39fLECky+CFKkAV8GYlX9eaI6IGmHQkY=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693 h1:83wvr6Z/+wiY9QVTkAlFdva2MF46so1NwDHSLMJpsG0=
-github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693/go.mod h1:9cjTZO4mYyk6BuPANVhOveyDCLYDnLagpdT+eAqhON8=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250304162904-aa2ddc2de8f9 h1:Hni5nKnC+j3ESm89h+c/r7ZNtS4Um2R1t5J905WNDkg=
+github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250304162904-aa2ddc2de8f9/go.mod h1:9cjTZO4mYyk6BuPANVhOveyDCLYDnLagpdT+eAqhON8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/controller/helpers/datamovement_helpers.go
+++ b/internal/controller/helpers/datamovement_helpers.go
@@ -308,7 +308,7 @@ func BuildDMCommand(profile *nnfv1alpha6.NnfDataMovementProfile, hostfile string
 
 func buildStatOrMkdirCommand(uid, gid uint32, cmd, setprivCmd, hostfile, path string, log logr.Logger) string {
 
-	// For DataIn/DataOut, dm is ran as root, so setpriv is needed to become the specified user. For
+	// For DataIn/DataOut, dm runs as root, so setpriv is needed to become the specified user. For
 	// copy offload, the user container is ran as the user, so setpriv is not needed.
 	if os.Getuid() != 0 {
 		setprivCmd = ""

--- a/internal/controller/helpers/datamovement_helpers.go
+++ b/internal/controller/helpers/datamovement_helpers.go
@@ -309,7 +309,7 @@ func BuildDMCommand(profile *nnfv1alpha6.NnfDataMovementProfile, hostfile string
 func buildStatOrMkdirCommand(uid, gid uint32, cmd, setprivCmd, hostfile, path string, log logr.Logger) string {
 
 	// For DataIn/DataOut, dm runs as root, so setpriv is needed to become the specified user. For
-	// copy offload, the user container is ran as the user, so setpriv is not needed.
+	// copy offload, the user container runs as the user, so setpriv is not needed.
 	if os.Getuid() != 0 {
 		setprivCmd = ""
 	}

--- a/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha6/nnfdatamovementprofile_types.go
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/api/v1alpha6/nnfdatamovementprofile_types.go
@@ -86,26 +86,34 @@ type NnfDataMovementProfileData struct {
 	// If CreateDestDir is true, then use StatCommand to perform the stat commands.
 	// Use setpriv to execute with the specified UID/GID.
 	// Available $VARS:
-	//   HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
+	//   HOSTFILE: Hostfile that is created and used for mpirun. Contains a list of hosts and the
 	//             slots/max_slots for each host. This hostfile is created at
 	//             `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
-	//   UID: User ID that is inherited from the Workflow
-	//   GID: Group ID that is inherited from the Workflow
+	//   SETPRIV: Placeholder for where to inject the SETPRIV command to become the UID/GID
+	//   		  inherited from the workflow.
 	//   PATH: Path to stat
-	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- setpriv --euid $UID --egid $GID --clear-groups stat --cached never -c '%F' $PATH"
+	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV stat --cached never -c '%F' $PATH"
 	StatCommand string `json:"statCommand"`
 
 	// If CreateDestDir is true, then use MkdirCommand to perform the mkdir commands.
 	// Use setpriv to execute with the specified UID/GID.
 	// Available $VARS:
-	//   HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
+	//   HOSTFILE: Hostfile that is created and used for mpirun. Contains a list of hosts and the
 	//             slots/max_slots for each host. This hostfile is created at
 	//             `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
+	//   SETPRIV: Placeholder for where to inject the SETPRIV command to become the UID/GID
+	//   		  inherited from the workflow.
+	//   PATH: Path to stat
+	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- $SETPRIV mkdir -p $PATH"
+	MkdirCommand string `json:"mkdirCommand"`
+
+	// The full setpriv command that is used to become the user and group specified in the workflow.
+	// This is used by the StatCommand and MkdirCommand.
+	// Available $VARS:
 	//   UID: User ID that is inherited from the Workflow
 	//   GID: Group ID that is inherited from the Workflow
-	//   PATH: Path to stat
-	// +kubebuilder:default:="mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE -- setpriv --euid $UID --egid $GID --clear-groups mkdir -p $PATH"
-	MkdirCommand string `json:"mkdirCommand"`
+	// +kubebuilder:default:="setpriv --euid $UID --egid $GID --clear-groups"
+	SetprivCommand string `json:"setprivCommand"`
 }
 
 // +kubebuilder:object:root=true

--- a/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
+++ b/vendor/github.com/NearNodeFlash/nnf-sos/config/crd/bases/nnf.cray.hpe.com_nnfdatamovementprofiles.yaml
@@ -362,17 +362,15 @@ spec:
                 type: integer
               mkdirCommand:
                 default: mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE --
-                  setpriv --euid $UID --egid $GID --clear-groups mkdir -p $PATH
-                description: |-
-                  If CreateDestDir is true, then use MkdirCommand to perform the mkdir commands.
-                  Use setpriv to execute with the specified UID/GID.
-                  Available $VARS:
-                    HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
-                              slots/max_slots for each host. This hostfile is created at
-                              `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
-                    UID: User ID that is inherited from the Workflow
-                    GID: Group ID that is inherited from the Workflow
-                    PATH: Path to stat
+                  $SETPRIV mkdir -p $PATH
+                description: "If CreateDestDir is true, then use MkdirCommand to perform
+                  the mkdir commands.\nUse setpriv to execute with the specified UID/GID.\nAvailable
+                  $VARS:\n  HOSTFILE: Hostfile that is created and used for mpirun.
+                  Contains a list of hosts and the\n            slots/max_slots for
+                  each host. This hostfile is created at\n            `/tmp/<dm-name>/hostfile`.
+                  This is the same hostfile used as the one for Command.\n  SETPRIV:
+                  Placeholder for where to inject the SETPRIV command to become the
+                  UID/GID\n  \t\t  inherited from the workflow.\n  PATH: Path to stat"
                 type: string
               pinned:
                 default: false
@@ -387,6 +385,15 @@ spec:
                   progress to be collected. A value of 0 disables this functionality.
                 minimum: 0
                 type: integer
+              setprivCommand:
+                default: setpriv --euid $UID --egid $GID --clear-groups
+                description: |-
+                  The full setpriv command that is used to become the user and group specified in the workflow.
+                  This is used by the StatCommand and MkdirCommand.
+                  Available $VARS:
+                    UID: User ID that is inherited from the Workflow
+                    GID: Group ID that is inherited from the Workflow
+                type: string
               slots:
                 default: 8
                 description: |-
@@ -396,18 +403,15 @@ spec:
                 type: integer
               statCommand:
                 default: mpirun --allow-run-as-root -np 1 --hostfile $HOSTFILE --
-                  setpriv --euid $UID --egid $GID --clear-groups stat --cached never
-                  -c '%F' $PATH
-                description: |-
-                  If CreateDestDir is true, then use StatCommand to perform the stat commands.
-                  Use setpriv to execute with the specified UID/GID.
-                  Available $VARS:
-                    HOSTFILE: hostfile that is created and used for mpirun. Contains a list of hosts and the
-                              slots/max_slots for each host. This hostfile is created at
-                              `/tmp/<dm-name>/hostfile`. This is the same hostfile used as the one for Command.
-                    UID: User ID that is inherited from the Workflow
-                    GID: Group ID that is inherited from the Workflow
-                    PATH: Path to stat
+                  $SETPRIV stat --cached never -c '%F' $PATH
+                description: "If CreateDestDir is true, then use StatCommand to perform
+                  the stat commands.\nUse setpriv to execute with the specified UID/GID.\nAvailable
+                  $VARS:\n  HOSTFILE: Hostfile that is created and used for mpirun.
+                  Contains a list of hosts and the\n            slots/max_slots for
+                  each host. This hostfile is created at\n            `/tmp/<dm-name>/hostfile`.
+                  This is the same hostfile used as the one for Command.\n  SETPRIV:
+                  Placeholder for where to inject the SETPRIV command to become the
+                  UID/GID\n  \t\t  inherited from the workflow.\n  PATH: Path to stat"
                 type: string
               storeStdout:
                 default: false
@@ -420,6 +424,7 @@ spec:
             - createDestDir
             - maxSlots
             - mkdirCommand
+            - setprivCommand
             - slots
             - statCommand
             type: object

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
 # github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c
 ## explicit; go 1.22.0
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250304162904-aa2ddc2de8f9
 ## explicit; go 1.22.0
 github.com/NearNodeFlash/nnf-sos/api/v1alpha6
 github.com/NearNodeFlash/nnf-sos/config/crd/bases

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20250221171407-1a51721c0739
+# github.com/DataWorkflowServices/dws v0.0.1-0.20250224211524-95e559ed4fa8
 ## explicit; go 1.22.0
 github.com/DataWorkflowServices/dws/api/v1alpha3
 github.com/DataWorkflowServices/dws/utils/dwdparse
@@ -7,10 +7,10 @@ github.com/DataWorkflowServices/dws/utils/updater
 ## explicit; go 1.22.0
 github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1
 github.com/NearNodeFlash/lustre-fs-operator/config/crd/bases
-# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250219193635-3e6c6b39d0e0
+# github.com/NearNodeFlash/nnf-ec v0.0.1-0.20250220202952-3c878bceb55c
 ## explicit; go 1.22.0
 github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models
-# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250221193225-b496a821842d
+# github.com/NearNodeFlash/nnf-sos v0.0.1-0.20250226162446-00a9dace0693
 ## explicit; go 1.22.0
 github.com/NearNodeFlash/nnf-sos/api/v1alpha6
 github.com/NearNodeFlash/nnf-sos/config/crd/bases


### PR DESCRIPTION
With the new copy offload container, the container is ran as the
specified user, so setpriv commands are not necessary to preserve the
proper permissions. However, for DataIn/DataOut DM, data movement is
still performed as root in the nnf-dm containers. Setpriv is necessary
in this case.

This change determines the UID of the user and appropriate uses/drops
the setprivCommand defined by the DM profile when issuing mkdir and stat
commands.

The same is done for the main DM command to remove --uid/--gid from dcp
when running in copy-offload.

These changes removes the need to have separate DM profiles for copy
offload.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
