### PR TITLE
Set a default location for the TLS cert on the compute node

### DIFF
--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -151,7 +151,6 @@ int copy_offload_configure(COPY_OFFLOAD *offload, char **host_and_port, int skip
         //curl_easy_setopt(curl, CURLOPT_SSL_VERIFYSTATUS, 1L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
 
-        fprintf(stderr, "Setting CAINFO to (%s)\n", offload->cacert);
         curl_easy_setopt(curl, CURLOPT_CAINFO, offload->cacert);
         curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
 

--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -126,18 +126,15 @@ int copy_offload_configure(COPY_OFFLOAD *offload, char **host_and_port, int skip
     int ret = 0;
 
     CURL *curl = offload->curl;
-    if (host_and_port != NULL)
-        offload->host_and_port = host_and_port;
+    offload->host_and_port = host_and_port;
     offload->skip_tls = skip_tls;
     if (cacert != NULL)
         offload->cacert = cacert;
-    if (key != NULL)
-        offload->key = key;
-    if (token_path != NULL)
-        offload->token_path = token_path;
-
-    if (clientcert != NULL)
-        offload->clientcert = clientcert;
+    else
+        offload->cacert = CERT_PATH;
+    offload->key = key;
+    offload->token_path = token_path;
+    offload->clientcert = clientcert;
     strncpy(offload->proto, "http", sizeof(offload->proto));
 
     struct curl_slist *chunk = NULL;
@@ -154,15 +151,16 @@ int copy_offload_configure(COPY_OFFLOAD *offload, char **host_and_port, int skip
         //curl_easy_setopt(curl, CURLOPT_SSL_VERIFYSTATUS, 1L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
 
-        curl_easy_setopt(curl, CURLOPT_CAINFO, cacert);
+        fprintf(stderr, "Setting CAINFO to (%s)\n", offload->cacert);
+        curl_easy_setopt(curl, CURLOPT_CAINFO, offload->cacert);
         curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
 
         // Are we doing mTLS?
         if (key != NULL && clientcert != NULL) {
-            curl_easy_setopt(curl, CURLOPT_SSLKEY, key);
+            curl_easy_setopt(curl, CURLOPT_SSLKEY, offload->key);
             curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PEM");
 
-            curl_easy_setopt(curl, CURLOPT_SSLCERT, clientcert);
+            curl_easy_setopt(curl, CURLOPT_SSLCERT, offload->clientcert);
             curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
         }
     }

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -29,6 +29,10 @@
 // The name of the environment variable that will contain the workflow's token.
 #define WORKFLOW_TOKEN_ENV "DW_WORKFLOW_TOKEN"
 
+// Default path of the TLS certificate. This should be a text file holding the
+// PEM form of the certificate.
+#define CERT_PATH "/etc/nnf-dm-usercontainer/cert.pem"
+
 struct copy_offload_s {
     CURL *curl;
     int skip_tls;
@@ -55,6 +59,8 @@ COPY_OFFLOAD *copy_offload_init();
 
 /* Store the host-and-port in the handle and set the basic configuration
  * for the handle.
+ * The @cacert path may be NULL, indicating that the default path of CERT_PATH
+ * should be used.
  * This will enable mTLS when @clientcert and @key are non-NULL, otherwise it will enable TLS.
  * If @skip_tls is set, then TLS/mTLS will not be enabled.
  * The token is normally taken from the DW_WORKFLOW_TOKEN environment variable,


### PR DESCRIPTION
Expect the TLS cert to be in "/etc/nnf-dm-usercontainer/cert.pem". Nnf-deploy already installs it in this location.