### PR TITLE
Containerize e2e-mocked tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,11 +215,6 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: setup go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-
     - name: "Lowercase repository name for docker build"
       id: lowercase-repository-name
       run: echo "REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -288,31 +283,9 @@ jobs:
       if: ${{ env.DO_TEST == 'true' && !env.ACT }}
       run: docker run ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
 
-    - name: "Install libcurl and shellcheck"
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libcurl4-openssl-dev shellcheck
- 
-    - name: "Do shellcheck"
-      run: shellcheck tools/*.sh daemons/copy-offload-testing/e2e-mocked.sh
-
-    - name: "Build lib-copy-offload"
-      run: make -C ./daemons/lib-copy-offload libcopyoffload.a
-
-    - name: "E2E mock test, without TLS or token"
-      run: SKIP_TLS=1 SKIP_TOKEN=1 ./daemons/copy-offload-testing/e2e-mocked.sh
-
-    - name: "E2E mock test, with TLS, without token"
-      run: SKIP_MTLS=1 SKIP_TOKEN=1 ./daemons/copy-offload-testing/e2e-mocked.sh
-
-    - name: "E2E mock test, with token, without TLS"
-      run: SKIP_TLS=1 ./daemons/copy-offload-testing/e2e-mocked.sh
-      
-    - name: "E2E mock test, with token and TLS (no mTLS)"
-      run: SKIP_MTLS=1 ./daemons/copy-offload-testing/e2e-mocked.sh
-
-    - name: "E2E mock test, with token and mTLS"
-      run: ./daemons/copy-offload-testing/e2e-mocked.sh
+    - name: "Build and run the Docker image unit tests in nektos/act"
+      if: ${{ env.DO_TEST == 'true' && env.ACT }}
+      run: make container-unit-test
 
     - name: "Build the copy-offload Docker image"
       if: ${{ !env.ACT }} # skip during local actions testing

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ test: manifests generate fmt vet envtest ## Run tests.
 		KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test -v ./$$subdir/... -coverprofile cover-$$(basename $$subdir.out) -ginkgo.v $$failfast; \
 	done
 
+within-container-unit-test: test
+	make -f daemons/copy-offload-testing/Makefile $@
+
 container-unit-test: VERSION ?= $(shell cat .version)
 container-unit-test: .version ## Run tests inside a container image
 	${CONTAINER_TOOL} build -f Dockerfile --label $(IMAGE_TAG_BASE)-$@:$(VERSION)-$@ -t $(IMAGE_TAG_BASE)-$@:$(VERSION) --target testing $(CONTAINER_BUILDARGS) .

--- a/daemons/copy-offload-testing/Makefile
+++ b/daemons/copy-offload-testing/Makefile
@@ -1,0 +1,40 @@
+# Copyright 2025 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all:
+
+.PHONY: within-container-unit-test
+within-container-unit-test: export SKIP_BUILD=1
+within-container-unit-test: e2e-mock
+
+.PHONY: e2e-mock
+e2e-mock:
+	# E2E mock test, without TLS or token
+	SKIP_TLS=1 SKIP_TOKEN=1 ./daemons/copy-offload-testing/e2e-mocked.sh
+
+	# E2E mock test, with token, without TLS
+	SKIP_TLS=1 ./daemons/copy-offload-testing/e2e-mocked.sh
+
+	# E2E mock test, with TLS, without token
+	SKIP_MTLS=1 SKIP_TOKEN=1 ./daemons/copy-offload-testing/e2e-mocked.sh
+
+	# E2E mock test, with token and TLS (no mTLS)
+	SKIP_MTLS=1 ./daemons/copy-offload-testing/e2e-mocked.sh
+
+	# E2E mock test, with token and mTLS
+	./daemons/copy-offload-testing/e2e-mocked.sh
+

--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -19,9 +19,10 @@
 
 set -o pipefail
 
-make build-copy-offload-local || exit 1
-
-make -C ./daemons/lib-copy-offload tester || exit 1
+if [[ -z $SKIP_BUILD ]]; then
+    make build-copy-offload-local || exit 1
+    make -C ./daemons/lib-copy-offload tester || exit 1
+fi
 CO="./daemons/lib-copy-offload/tester ${SKIP_TLS:+-s}"
 SRVR="localhost:4000"
 PROTO="http"

--- a/hack/make-kustomization2.sh
+++ b/hack/make-kustomization2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -34,7 +34,7 @@ fi
 COMPONENT_LABELS="
     - op: add
       path: /metadata/labels/app.kubernetes.io~1version
-      value: "$TAG_NNF_DM"
+      value: $TAG_NNF_DM
     - op: add
       path: /metadata/labels/app.kubernetes.io~1component
       value: nnf-dm
@@ -46,7 +46,7 @@ then
     NNF_VER_LABELS="
     - op: add
       path: /metadata/labels/app.kubernetes.io~1nnf-version
-      value: "$NNF_VERSION"
+      value: $NNF_VERSION
     - op: add
       path: /metadata/labels/app.kubernetes.io~1part-of
       value: nnf


### PR DESCRIPTION
Move the e2e-mocked test commandlines out of the github workflow and into a new makefile. Adjust e2e-mocked to use the binaries created in the Dockerfile rather than running 'make' commands on its own.

Modify the top makefile's "container-unit-test" target to run these tests.

Adjust the Dockerfile to run these tests. Arrange the build stages so it can run these new things in parallel.

The Dockerfile also runs 'shellcheck' in a build stage. Include a shellcheck fix for an issue found in hack/make-kustomization2.sh.