### PR TITLE
Cleanup copy-offload library API

### DIFF
--- a/daemons/copy-offload-testing/Makefile
+++ b/daemons/copy-offload-testing/Makefile
@@ -32,9 +32,6 @@ e2e-mock:
 	# E2E mock test, with TLS, without token
 	SKIP_MTLS=1 SKIP_TOKEN=1 ./daemons/copy-offload-testing/e2e-mocked.sh
 
-	# E2E mock test, with token and TLS (no mTLS)
-	SKIP_MTLS=1 ./daemons/copy-offload-testing/e2e-mocked.sh
-
-	# E2E mock test, with token and mTLS
+	# E2E mock test, with token and TLS
 	./daemons/copy-offload-testing/e2e-mocked.sh
 

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -37,10 +37,9 @@ struct copy_offload_s {
     CURL *curl;
     int skip_tls;
     char **host_and_port;
+    int cert_and_token_done;
     char *cacert;
-    char *key;
-    char *clientcert;
-    char *token_path;
+    char *token;
     char proto[6];
 
     /* The post-processed error message. If there was an error from libcurl, then
@@ -59,17 +58,30 @@ COPY_OFFLOAD *copy_offload_init();
 
 /* Store the host-and-port in the handle and set the basic configuration
  * for the handle.
- * The @cacert path may be NULL, indicating that the default path of CERT_PATH
- * should be used.
- * This will enable mTLS when @clientcert and @key are non-NULL, otherwise it will enable TLS.
- * If @skip_tls is set, then TLS/mTLS will not be enabled.
- * The token is normally taken from the DW_WORKFLOW_TOKEN environment variable,
- * if it exists. If @token_path is supplied then it overrides the DW_WORKFLOW_TOKEN
- * variable. If neither is found then no token is used.
+ * If @skip_tls is set, then TLS will not be enabled.
  * Returns 0 on success.
  * On failure, returns 1 and places the error message in @offload->err_message. 
  */
-int copy_offload_configure(COPY_OFFLOAD *offload, char **host_and_port, int skip_tls, char *cacert, char *key, char *clientcert, char *token_path);
+int copy_offload_configure(COPY_OFFLOAD *offload, char **host_and_port, int skip_tls);
+
+/* Override the default certificate path. By default, the certificate will be
+ * read from CERT_PATH, as set by the administrator. This may be overridden by
+ * placing the PEM form of the certificate in the @cert_path file.
+ * This may be called any time before the first message is sent to the server.
+ * Returns 0 on success.
+ * On failure, returns 1 and places the error message in @offload->err_message. 
+ */
+int copy_offload_override_cert(COPY_OFFLOAD *offload, char *cert_path);
+
+/* Override the default token. By default, the token will be found in the
+ * $DW_WORKFLOW_TOKEN environment variable.
+ * Set @token_path to NULL to not use a token, or set it to a file that contains
+ * the token if not using the environment variable.
+ * This may be called any time before the first message is sent to the server.
+ * Returns 0 on success.
+ * On failure, returns 1 and places the error message in @offload->err_message. 
+ */
+int copy_offload_override_token(COPY_OFFLOAD *offload, char *token_path);
 
 /* Reset the handle so it can be used for the next command.
  * After this, the handle is ready for things like the following:


### PR DESCRIPTION
Simplify copy_offload_configure() by removing the token and cert paths. Let it rely on the defaults for those. Provide two functions to override the defaults.

This adds copy_offload_override_cert() to override the default filename that is used for the TLS certificate.

This adds copy_offload_override_token() to override the default location to find the token.

Remove support for mTLS from the library, the server, and the e2e-mocked tests.