### PR TITLE
Add req_distinguished name to the openssl config file

### DIFF
--- a/tools/gen_certs.sh
+++ b/tools/gen_certs.sh
@@ -39,7 +39,12 @@ mkdir -p "$CA_DIR" && chmod 700 "$CA_DIR"
 if [[ -z $SKIP_SAN ]]; then
     ./tools/mk-rabbit-san.sh "$CERTDIR" "$RABBIT_SAN_CONF" || exit 1
 else
-    if ! echo "[v3_req]
+    if ! echo "[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+C = US
+[v3_req]
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = $SRVR_HOST

--- a/tools/mk-rabbit-san.sh
+++ b/tools/mk-rabbit-san.sh
@@ -55,7 +55,12 @@ make_rabbit_san_conf()
         exit 1
     fi
 
-    if ! echo "[v3_req]
+    if ! echo "[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+C = US
+[v3_req]
 subjectAltName = @alt_names
 [alt_names]" > "$SAN_CONF"; then
         echo "Unable to start the SAN conf file"


### PR DESCRIPTION
Some versions of openssl require more pieces in the config file.