### PR TITLE
Copy Offload API: Use MPI Operator to drive

### DIFF
--- a/config/copy-offload/copy_offload_role.yaml
+++ b/config/copy-offload/copy_offload_role.yaml
@@ -29,6 +29,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - dataworkflowservices.github.io
+  resources:
+  - systemconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - nnf.cray.hpe.com
   resources:
   - nnfdatamovementprofiles
@@ -56,6 +64,14 @@ rules:
   - nnf.cray.hpe.com
   resources:
   - nnfstorages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
   verbs:
   - get
   - list

--- a/config/examples/copyoffload-containerprofile.yaml
+++ b/config/examples/copyoffload-containerprofile.yaml
@@ -11,24 +11,38 @@ data:
     - name: DW_GLOBAL_lus
       optional: false
   numPorts: 1
-  spec:
-    containers:
-      - name: copy-offload-srvr
-        image: nnf-dm-copy-offload:latest
-        command:
-          - /nnf-copy-offload
-          - --cert
-          - $(TLS_CERT_PATH)
-          - --cakey
-          - $(TLS_KEY_PATH)
-          - --tokenkey
-          - $(TOKEN_KEY_PATH)
-          - --addr
-          - :$(NNF_CONTAINER_PORTS)
-    # This ServiceAccount is used by the nnf-dm-copy-offload server to talk to
-    # the Kubernetes API server. This ServiceAccount and its Role are
-    # defined in config/copy-offload.
-    # Normal user containers should not require Kubernetes API server privilege
-    # and should not have a service account.
-    serviceAccountName: nnf-dm-copy-offload
   retryLimit: 2
+  # Copy offload needs to use mpiSpec to use the mpi-operator model
+  # TODO: Add a webhook check that any template with a serviceAccountName == nnf-dm-copy-offload
+  # needs to have an mpiSpec
+  mpiSpec:
+    runPolicy:
+      cleanPodPolicy: Running
+    mpiReplicaSpecs:
+      Launcher:
+        template:
+          spec:
+            containers:
+              - name: copy-offload-srvr
+                image: ghcr.io/nearnodeflash/nnf-dm-copy-offload:latest
+                command:
+                  - /nnf-copy-offload
+                  - --cert
+                  - $(TLS_CERT_PATH)
+                  - --cakey
+                  - $(TLS_KEY_PATH)
+                  - --tokenkey
+                  - $(TOKEN_KEY_PATH)
+                  - --addr
+                  - :$(NNF_CONTAINER_PORTS)
+            # This ServiceAccount is used by the nnf-dm-copy-offload server to talk to the
+            # Kubernetes API server. This ServiceAccount and its Role are defined in
+            # config/copy-offload.  Normal user containers should not require Kubernetes API server
+            # privilege and should not have a service account.
+            serviceAccountName: nnf-dm-copy-offload
+      Worker:
+        template:
+          spec:
+            containers:
+              - name: copy-offload-worker
+                image: ghcr.io/nearnodeflash/nnf-dm-copy-offload:latest

--- a/daemons/copy-offload/cmd/main.go
+++ b/daemons/copy-offload/cmd/main.go
@@ -41,6 +41,7 @@ import (
 	zapcr "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	dwsv1alpha3 "github.com/DataWorkflowServices/dws/api/v1alpha3"
+	lusv1beta1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1"
 	"github.com/NearNodeFlash/nnf-dm/daemons/copy-offload/pkg/driver"
 	userHttp "github.com/NearNodeFlash/nnf-dm/daemons/copy-offload/pkg/server"
 	nnfv1alpha6 "github.com/NearNodeFlash/nnf-sos/api/v1alpha6"
@@ -55,6 +56,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(nnfv1alpha6.AddToScheme(scheme))
 	utilruntime.Must(dwsv1alpha3.AddToScheme(scheme))
+	utilruntime.Must(lusv1beta1.AddToScheme(scheme))
 }
 
 func setupLog() logr.Logger {
@@ -111,7 +113,7 @@ func main() {
 
 	crLog := setupLog()
 	// Make one of these for this server, and use it in all requests.
-	drvr := &driver.Driver{Log: crLog, RabbitName: rabbitName, Mock: mock}
+	drvr := &driver.Driver{Log: crLog, Mock: mock}
 
 	if !skipTls {
 		serverTLSCert, err := tls.LoadX509KeyPair(*certFile, *keyFile)

--- a/daemons/copy-offload/pkg/driver/driver.go
+++ b/daemons/copy-offload/pkg/driver/driver.go
@@ -57,9 +57,8 @@ var (
 // Driver will have only one instance per process, shared by all threads
 // in the process.
 type Driver struct {
-	Client     client.Client
-	Log        logr.Logger
-	RabbitName string
+	Client client.Client
+	Log    logr.Logger
 
 	Mock      bool
 	MockCount int
@@ -92,6 +91,9 @@ type DriverRequest struct {
 	hosts []string
 	// MPI hosts file.
 	mpiHostfile string
+	// Rabbit node targeted for data movement. This is the local node attach to the requesting
+	// compute node.
+	RabbitName string
 }
 
 func (r *DriverRequest) Create(ctx context.Context, dmreq DMRequest) (*nnfv1alpha6.NnfDataMovement, error) {
@@ -107,7 +109,7 @@ func (r *DriverRequest) Create(ctx context.Context, dmreq DMRequest) (*nnfv1alph
 	}
 	if workflow.Status.State != dwsv1alpha3.StatePreRun || workflow.Status.Status != "Completed" {
 		err := fmt.Errorf("workflow must be in '%s' state and 'Completed' status", dwsv1alpha3.StatePreRun)
-		crLog.Info("Workflow is in an invalid state: %v", err)
+		crLog.Error(err, "Workflow is in an invalid state")
 		return nil, err
 	}
 
@@ -116,6 +118,14 @@ func (r *DriverRequest) Create(ctx context.Context, dmreq DMRequest) (*nnfv1alph
 		crLog.Error(err, "Failed to retrieve compute mountinfo")
 		return nil, err
 	}
+
+	// Determine which rabbit is local to the compute that made the request
+	rabbit, err := r.findRabbitNameFromCompute(dmreq.ComputeName)
+	if err != nil {
+		crLog.Error(err, "Failed to trace compute node to its rabbit node")
+		return nil, err
+	}
+	r.RabbitName = rabbit
 
 	crLog = crLog.WithValues("type", computeMountInfo.Type)
 	var dm *nnfv1alpha6.NnfDataMovement
@@ -132,7 +142,7 @@ func (r *DriverRequest) Create(ctx context.Context, dmreq DMRequest) (*nnfv1alph
 	}
 
 	if err != nil {
-		crLog.Error(err, "Failed to copy files")
+		crLog.Error(err, "Failed to create DM request")
 		return nil, err
 	}
 
@@ -184,12 +194,11 @@ func (r *DriverRequest) generateName(dm *nnfv1alpha6.NnfDataMovement) {
 }
 
 func (r *DriverRequest) CreateMock(ctx context.Context, dmreq DMRequest) (*nnfv1alpha6.NnfDataMovement, error) {
-	drvr := r.Drvr
 
 	dm := &nnfv1alpha6.NnfDataMovement{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: nodeNameBase,
-			Namespace:    drvr.RabbitName, // Use the rabbit
+			Namespace:    r.RabbitName, // Use the rabbit
 			Labels: map[string]string{
 				nnfv1alpha6.DataMovementInitiatorLabel: dmreq.ComputeName,
 			},
@@ -211,14 +220,15 @@ func (r *DriverRequest) Drive(ctx context.Context, dmreq DMRequest, dm *nnfv1alp
 		return err
 	}
 
-	r.hosts, err = helpers.GetWorkerHostnames(drvr.Client, ctx, r.nodes)
+	// Get the FQDNs of the worker nodes so we can use them to create the mpirun hostfile
+	r.hosts, err = helpers.GetCopyOffloadWorkerHostnames(drvr.Client, ctx, r.nodes, dmreq.WorkflowName, dmreq.WorkflowNamespace, dm)
 	if err != nil {
 		crLog.Error(err, "could not get worker nodes for data movement")
 		return err
 	}
 
-	// Create the hostfile. This is needed for preparing the destination and the data movement
-	// command itself.
+	// Create the hostfile used by `mpirun`. This is needed for preparing the destination
+	// and the data movement command itself.
 	r.mpiHostfile, err = helpers.CreateMpiHostfile(r.dmProfile, r.hosts, dm)
 	if err != nil {
 		crLog.Error(err, "could not create MPI hostfile")
@@ -306,7 +316,7 @@ func (r *DriverRequest) driveWithContext(ctx context.Context, ctxCancel context.
 	}
 
 	// Build command
-	cmdArgs, err := helpers.BuildDMCommand(r.dmProfile, r.mpiHostfile, dm, crLog)
+	cmdArgs, err := helpers.BuildDMCommand(r.dmProfile, r.mpiHostfile, false, dm, crLog)
 	if err != nil {
 		crLog.Error(err, "could not create data movement command")
 		return err
@@ -509,6 +519,10 @@ func setUserConfig(dmreq DMRequest, dm *nnfv1alpha6.NnfDataMovement) {
 	dm.Spec.UserConfig.LogStdout = dmreq.LogStdout
 	dm.Spec.UserConfig.StoreStdout = dmreq.StoreStdout
 
+	// TODO: Even though these aren't set explicity by copy offload API, they are getting
+	// overwritten. Investigate this. The profile says 8, but we only get 1 slot. I did remove
+	// slotsPerWorker from the container profile, so perhaps mpi-operator is doing someting extra
+	// there too.
 	if dmreq.Slots >= 0 {
 		dm.Spec.UserConfig.Slots = pointy.Int(int(dmreq.Slots))
 	}
@@ -587,7 +601,6 @@ func getDirectiveIndexFromClientMount(object *dwsv1alpha3.ClientMount) (string, 
 
 // createNnfNodeDataMovement creates an NnfDataMovement to be used with GFS2.
 func (r *DriverRequest) createNnfNodeDataMovement(ctx context.Context, dmreq DMRequest, computeMountInfo *dwsv1alpha3.ClientMountInfo) (*nnfv1alpha6.NnfDataMovement, error) {
-	drvr := r.Drvr
 
 	// Find the ClientMount for the rabbit.
 	source, err := r.findRabbitRelativeSource(ctx, dmreq, computeMountInfo)
@@ -598,7 +611,7 @@ func (r *DriverRequest) createNnfNodeDataMovement(ctx context.Context, dmreq DMR
 	dm := &nnfv1alpha6.NnfDataMovement{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: nodeNameBase,
-			Namespace:    drvr.RabbitName, // Use the rabbit
+			Namespace:    r.RabbitName, // Use the rabbit
 			Labels: map[string]string{
 				nnfv1alpha6.DataMovementInitiatorLabel: dmreq.ComputeName,
 			},
@@ -624,7 +637,7 @@ func (r *DriverRequest) findRabbitRelativeSource(ctx context.Context, dmreq DMRe
 	// to this value resulting in the full path on the Rabbit.
 
 	listOptions := []client.ListOption{
-		client.InNamespace(drvr.RabbitName),
+		client.InNamespace(r.RabbitName),
 		client.MatchingLabels(map[string]string{
 			dwsv1alpha3.WorkflowNameLabel:      dmreq.WorkflowName,
 			dwsv1alpha3.WorkflowNamespaceLabel: dmreq.WorkflowNamespace,
@@ -637,7 +650,7 @@ func (r *DriverRequest) findRabbitRelativeSource(ctx context.Context, dmreq DMRe
 	}
 
 	if len(clientMounts.Items) == 0 {
-		return "", fmt.Errorf("no client mounts found for node '%s'", drvr.RabbitName)
+		return "", fmt.Errorf("no client mounts found for node '%s'", r.RabbitName)
 	}
 
 	for _, clientMount := range clientMounts.Items {
@@ -762,4 +775,25 @@ func (r *DriverRequest) selectProfile(ctx context.Context, dmreq DMRequest) (*nn
 	}
 
 	return profile, nil
+}
+
+// Use the systemconfiguration to find the compute node's local rabbit node
+func (r *DriverRequest) findRabbitNameFromCompute(compute string) (string, error) {
+	drvr := r.Drvr
+	systemConfigName := "default"
+
+	systemConfig := &dwsv1alpha3.SystemConfiguration{}
+	if err := drvr.Client.Get(context.TODO(), types.NamespacedName{Name: systemConfigName, Namespace: corev1.NamespaceDefault}, systemConfig); err != nil {
+		return "", fmt.Errorf("failed to retrieve system configuration: %w", err)
+	}
+
+	for _, storageNode := range systemConfig.Spec.StorageNodes {
+		for _, computeNode := range storageNode.ComputesAccess {
+			if computeNode.Name == compute {
+				return storageNode.Name, nil
+			}
+		}
+	}
+
+	return "", nil
 }

--- a/daemons/copy-offload/pkg/server/server_test.go
+++ b/daemons/copy-offload/pkg/server/server_test.go
@@ -308,7 +308,7 @@ func TestD_TrialRequest(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := &driver.Driver{Log: crLog, RabbitName: "rabbit-1", Mock: true}
+	drvr := &driver.Driver{Log: crLog, Mock: true}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	for _, test := range testCases {
@@ -369,7 +369,7 @@ func TestE_Lifecycle(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := &driver.Driver{Log: crLog, RabbitName: "rabbit-1", Mock: true}
+	drvr := &driver.Driver{Log: crLog, Mock: true}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	var listWanted []string

--- a/internal/controller/datamovement_controller.go
+++ b/internal/controller/datamovement_controller.go
@@ -206,7 +206,7 @@ func (r *DataMovementReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Build command
-	cmdArgs, err := BuildDMCommand(profile, mpiHostfile, dm, log)
+	cmdArgs, err := BuildDMCommand(profile, mpiHostfile, true, dm, log)
 	if err != nil {
 		return ctrl.Result{}, dwsv1alpha3.NewResourceError("could not create data movement command").WithError(err).WithMajor()
 	}

--- a/internal/controller/datamovement_controller_test.go
+++ b/internal/controller/datamovement_controller_test.go
@@ -805,7 +805,7 @@ var _ = Describe("Data Movement Test", func() {
 						"mpirun --extra opts --allow-run-as-root --hostfile /tmp/hostfile dcp --progress 1 --uid %d --gid %d %s %s",
 						expectedUid, expectedGid, srcPath, destPath)
 
-					cmd, err := BuildDMCommand(&profile, "/tmp/hostfile", &dm, log.FromContext(context.TODO()))
+					cmd, err := BuildDMCommand(&profile, "/tmp/hostfile", true, &dm, log.FromContext(context.TODO()))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(strings.Join(cmd, " ")).Should(MatchRegexp(expectedCmdRegex))
 				})
@@ -823,7 +823,7 @@ var _ = Describe("Data Movement Test", func() {
 						"mpirun --allow-run-as-root --hostfile /tmp/hostfile dcp --extra opts --progress 1 --uid %d --gid %d %s %s",
 						expectedUid, expectedGid, srcPath, destPath)
 
-					cmd, err := BuildDMCommand(&profile, "/tmp/hostfile", &dm, log.FromContext(context.TODO()))
+					cmd, err := BuildDMCommand(&profile, "/tmp/hostfile", true, &dm, log.FromContext(context.TODO()))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(strings.Join(cmd, " ")).Should(MatchRegexp(expectedCmdRegex))
 				})


### PR DESCRIPTION
The current copy offload API design does not work for lustre-to-lustre data movement, where every rabbit in the workflow needs to get involved.

For background, GFS2-to-lustre data movement is node-local, meaning that only one rabbit is used to transfer the node-local GFS2 filesystem from the rabbit to global lustre. Since a lustre filesystem can be spread across multiple rabbit nodes, each rabbit must be contacted to orchestrate the data movement across the nodes.

To support this with user containers for copy offload, SSH keys must be set up so that each rabbit can contact any other rabbit. The mpi-operator takes care of this orchestration for us, and mpirun can be used to run jobs (e.g., dcp) on each rabbit node.

With this model, we get one launcher pod for the workflow, and then each rabbit gets a worker pod. The launcher pod is responsible for launching the mpirun job across the worker pods. The launcher pod is running the Copy Offload server, which will be contacted by the compute nodes to communicate with the Copy Offload API.

A new environment variable is added to nnf-sos so that compute nodes know how to contact the Copy Offload API.

For GFS2 data movement, the server must use the compute node that is making the request and trace back to its local rabbit. The software then must contact the worker pod that is running on that rabbit to initiate data movement with mpirun using only that worker pod. In contrast, for lustre data movement, all of the worker pods running on all of the rabbits for the workflow are used.