### PR TITLE
Do all copy-offload request setup in driver.Create

### DIFF
--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -60,7 +60,7 @@ fi
 
 set -x
 # shellcheck disable=SC2086
-NNF_NODE_NAME=rabbit01 $SRVR_CMD $SRVR_CMD_TOKEN_ARGS $SRVR_CMD_TLS_ARGS &
+NNF_NODE_NAME=rabbit01 ENVIRONMENT=test $SRVR_CMD $SRVR_CMD_TOKEN_ARGS $SRVR_CMD_TLS_ARGS &
 srvr_pid=$!
 set +x
 echo "Server pid is $srvr_pid, my pid is $$"
@@ -106,12 +106,12 @@ if [[ $output != "" ]]; then
 fi
 
 # shellcheck disable=SC2086
-if ! output=$($CO $CO_TLS_ARGS -c nnf-copy-offload-node-2 "$SRVR"); then
+if output=$($CO $CO_TLS_ARGS -c nnf-copy-offload-node-2 "$SRVR"); then
     echo "line $LINENO output: $output"
     cleanup
 fi
-if [[ $output != "" ]]; then
-    echo "FAIL: Expected empty output from cancel before any jobs have been submitted"
+if [[ $output != "unable to cancel request: request not found" ]]; then
+    echo "FAIL: Expected cancel to not find my request before any jobs have been submitted"
     kill "$srvr_pid"
     exit 1
 fi

--- a/daemons/copy-offload/cmd/main.go
+++ b/daemons/copy-offload/cmd/main.go
@@ -110,6 +110,11 @@ func main() {
 		slog.Error("Did not find NNF_NODE_NAME")
 		os.Exit(1)
 	}
+	if os.Getenv("ENVIRONMENT") == "" {
+		// "production" or "kind" or "test"
+		slog.Error("Did not find ENVIRONMENT")
+		os.Exit(1)
+	}
 
 	crLog := setupLog()
 	// Make one of these for this server, and use it in all requests.

--- a/daemons/copy-offload/pkg/server/server.go
+++ b/daemons/copy-offload/pkg/server/server.go
@@ -143,7 +143,7 @@ func (user *UserHttp) CancelRequest(w http.ResponseWriter, req *http.Request) {
 
 	drvrReq := driver.DriverRequest{Drvr: user.Drvr}
 	if err := drvrReq.CancelRequest(context.TODO(), name); err != nil {
-		http.Error(w, fmt.Sprintf("unable to cancel request: %s\n", err.Error()), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("unable to cancel request: %s", err.Error()), http.StatusNotFound)
 		return
 	}
 	http.Error(w, "", http.StatusNoContent)


### PR DESCRIPTION
Move all setup steps into driver.Create(). If any of that fails then the error is reported in the HTTP result of the copy-offload request, and there is no NnfDataMovement resource.

This means that driver.Drive() can be focused on actually running the copy command. In the next step, any status or result from the copy command can be recorded in the NnfDataMovement resource.

Make copy-offload server mock mode more useful by allowing to actually run a command.

Adjust the 'cancel' test to allow commands time to terminate.