### PR TITLE
copy offload: Add slots/max_slots to copy_offload_copy() and tester

### DIFF
--- a/daemons/copy-offload/pkg/driver/dmrequest.go
+++ b/daemons/copy-offload/pkg/driver/dmrequest.go
@@ -77,6 +77,12 @@ func (m *DMRequest) Validator() error {
 	if m.WorkflowNamespace == "" {
 		m.WorkflowNamespace = corev1.NamespaceDefault
 	}
+	if m.Slots < -1 {
+		return fmt.Errorf("slots must be -1 (defer to profile), 0 (disable), or a positive integer")
+	}
+	if m.MaxSlots < -1 {
+		return fmt.Errorf("maxSlots must be -1 (defer to profile), 0 (disable), or a positive integer")
+	}
 
 	return nil
 }

--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -49,7 +49,7 @@ static int read_contents(COPY_OFFLOAD *offload, char *path, char **buffer) {
         snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE-1, "Unable to stat %s: errno %d\n", path, errno);
         return 1;
     }
-    if ((*buffer = malloc(stat_blk.st_size + 1)) == NULL) {
+    if ((*buffer = (char *)malloc(stat_blk.st_size + 1)) == NULL) {
         snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE-1, "Unable to allocate a buffer for the bearer token\n");
         return 1;
     }
@@ -87,7 +87,7 @@ static size_t cb(void *data, size_t size, size_t nmemb, void *clientp) {
     size_t realsize = size * nmemb;
     struct memory *mem = (struct memory *)clientp;
 
-    char *ptr = realloc(mem->response, mem->size + realsize + 1);
+    char *ptr = (char *)realloc(mem->response, mem->size + realsize + 1);
     if(!ptr) {
         return 0;
     }
@@ -103,7 +103,7 @@ static size_t cb(void *data, size_t size, size_t nmemb, void *clientp) {
 /* Create and initialize a handle. */
 COPY_OFFLOAD *copy_offload_init() {
     CURL *curl;
-    COPY_OFFLOAD *offload = malloc(sizeof(struct copy_offload_s));
+    COPY_OFFLOAD *offload = (COPY_OFFLOAD *)malloc(sizeof(struct copy_offload_s));
 
     curl_global_init(CURL_GLOBAL_ALL);
     curl = curl_easy_init();
@@ -316,7 +316,7 @@ int copy_offload_cancel(COPY_OFFLOAD *offload, char *job_name, char **output) {
 /* Submit a new copy-offload request.
  * The caller is responsible for calling free() on @output if *output is non-NULL.
  */
-int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_name, const char *profile_name, int dry_run, char *source_path, char *dest_path, char **output) {
+int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_name, const char *profile_name, int slots, int max_slots, int dry_run, char *source_path, char *dest_path, char **output) {
     long http_code;
     struct memory chunk = {NULL, 0};
     int ret = 1;
@@ -338,7 +338,7 @@ int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_
         strcpy(dry_run_str, "false");
     }
 
-    char *offload_req =
+    const char *offload_req =
         "{\"computeName\": \"%s\", "
         "\"workflowName\": \"%s\", "
         "\"sourcePath\": \"%s\", "
@@ -347,9 +347,11 @@ int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_
         "\"dryrun\": %s, "
         "\"dcpOptions\": \"\", "
         "\"logStdout\": true, "
-        "\"storeStdout\": false}";
-    n = snprintf(postbuf, COPY_OFFLOAD_POST_SIZE, offload_req, compute_name, workflow_name, source_path, dest_path, profile_name, dry_run_str);
-    if (n >= sizeof(postbuf)) {
+        "\"storeStdout\": false, "
+        "\"slots\": %d, "
+        "\"maxSlots\": %d}";
+    n = snprintf(postbuf, COPY_OFFLOAD_POST_SIZE, offload_req, compute_name, workflow_name, source_path, dest_path, profile_name, dry_run_str, slots, max_slots);
+    if (n >= (int)sizeof(postbuf)) {
         snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE, "Error formatting request: request truncated, buffer too small");
         return ret;
     } else if (n < 0) {

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -114,7 +114,7 @@ int copy_offload_cancel(COPY_OFFLOAD *offload, char *job_name, char **output);
  * Returns 0 on success.
  * On failure it returns 1 and places an error message in @offload->err_message.
  */
-int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_name, const char *profile_name, int dry_run, char *source_path, char *dest_path, char **output);
+int copy_offload_copy(COPY_OFFLOAD *offload, char *compute_name, char *workflow_name, const char *profile_name, int slots, int max_slots, int dry_run, char *source_path, char *dest_path, char **output);
 
 /* Clean up the handle's resources. */
 void copy_offload_cleanup(COPY_OFFLOAD *offload);

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -47,6 +47,8 @@ void usage(const char **argv) {
     fprintf(stderr, "       -P DM_PROFILE_NAME Name of the DM profile to use (optional).\n");
     fprintf(stderr, "       -S SOURCE_PATH     Local path to source file to be copied.\n");
     fprintf(stderr, "       -D DEST_PATH       Local path to destination.\n");
+    fprintf(stderr, "       -m SLOTS           Number of slots (processes).\n");
+    fprintf(stderr, "       -M MAX_SLOTS       Maximum number of slots (processes).\n");
     fprintf(stderr, "       -d                 Perform a dry run.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "COMMON_ARGS\n");
@@ -81,9 +83,11 @@ int main(int argc, const char **argv) {
     char *token_path = NULL;
     int dry_run = 0;
     int skip_tls = 0;
+    int slots = -1; /* -1 defers to dm profile, 0 disables slots */
+    int max_slots = -1;
     int ret;
 
-    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:W:P:S:D:d")) != -1) {
+    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:W:P:S:D:m:M:d")) != -1) {
         switch (c) {
             case 'c':
                 c_opt = 1;
@@ -118,6 +122,12 @@ int main(int argc, const char **argv) {
                 break;
             case 'D':
                 dest_path = optarg;
+                break;
+            case 'm':
+                slots = atoi(optarg);
+                break;
+            case 'M':
+                max_slots = atoi(optarg);
                 break;
             case 'd':
                 dry_run = 1;
@@ -178,7 +188,7 @@ int main(int argc, const char **argv) {
     } else if (c_opt) {
         ret = copy_offload_cancel(offload, job_name, &output);
     } else if (o_opt) {
-        ret = copy_offload_copy(offload, compute_name, workflow_name, profile_name, dry_run, source_path, dest_path, &output);
+        ret = copy_offload_copy(offload, compute_name, workflow_name, profile_name, slots, max_slots, dry_run, source_path, dest_path, &output);
     } else {
         fprintf(stderr, "What action?\n");
         copy_offload_cleanup(offload);


### PR DESCRIPTION
This was defaulted to 0, which disables slots/maxSlots on the server
side. We want this to default to -1 to defer to the slots and
maxSlots set by the DM profile.

These options allows users to set the slots/max_slots in the mpirun
hostfile for any request. This allows the user to pick how many
processes dcp should be ran with on each host (i.e. rabbit).

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
