### PR TITLE
Get the workflow from the container env

### DIFF
--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -62,7 +62,7 @@ fi
 
 set -x
 # shellcheck disable=SC2086
-NNF_NODE_NAME=rabbit01 ENVIRONMENT=test $SRVR_CMD $SRVR_CMD_TOKEN_ARGS $SRVR_CMD_TLS_ARGS &
+NNF_NODE_NAME=rabbit01 ENVIRONMENT=test DW_WORKFLOW_NAME=yellow DW_WORKFLOW_NAMESPACE=default $SRVR_CMD $SRVR_CMD_TOKEN_ARGS $SRVR_CMD_TLS_ARGS &
 srvr_pid=$!
 set +x
 echo "Server pid is $srvr_pid, my pid is $$"
@@ -96,8 +96,6 @@ if [[ $output != "hello back at ya" ]]; then
     exit 1
 fi
 
-export DW_WORKFLOW_NAME=yellow
-export DW_WORKFLOW_NAMESPACE=default
 export NNF_CONTAINER_PORTS="$SRVR_PORT"
 export NNF_CONTAINER_LAUNCHER="$SRVR_NAME"
 

--- a/daemons/copy-offload/cmd/main.go
+++ b/daemons/copy-offload/cmd/main.go
@@ -118,7 +118,11 @@ func main() {
 
 	crLog := setupLog()
 	// Make one of these for this server, and use it in all requests.
-	drvr := driver.NewDriver(crLog, mock)
+	drvr, err := driver.NewDriver(crLog, mock)
+	if err != nil {
+		slog.Error("Unable to create driver", "error", err.Error())
+		os.Exit(1)
+	}
 
 	if !skipTls {
 		serverTLSCert, err := tls.LoadX509KeyPair(*certFile, *keyFile)
@@ -179,7 +183,6 @@ func main() {
 		TLSConfig: tlsConfig,
 	}
 
-	var err error
 	if !skipTls {
 		err = srv.ListenAndServeTLS("", "")
 	} else {

--- a/daemons/copy-offload/pkg/driver/dmrequest.go
+++ b/daemons/copy-offload/pkg/driver/dmrequest.go
@@ -21,8 +21,6 @@ package driver
 
 import (
 	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // DMRequest represents the content of one http request. This has a
@@ -31,9 +29,6 @@ import (
 type DMRequest struct {
 	ComputeName string `json:"computeName"`
 
-	// The name and namespace of the initiating workflow
-	WorkflowName      string `json:"workflowName"`
-	WorkflowNamespace string `json:"workflowNamespace"`
 	// Source file or directory
 	SourcePath string `json:"sourcePath"`
 	// Destination file or directory
@@ -65,9 +60,6 @@ type DMRequest struct {
 // one-to-one relationship with a DriverRequest object.
 // This is the v1.0 apiVersion. See COPY_OFFLOAD_API_VERSION.
 type StatusRequest struct {
-	// The name and namespace of the initiating workflow
-	WorkflowName      string `json:"workflowName"`
-	WorkflowNamespace string `json:"workflowNamespace"`
 	// Name of the copy request.
 	RequestName string `json:"requestName"`
 	// Max number of seconds to wait for the completion of the copy request.
@@ -80,17 +72,11 @@ func (m *DMRequest) Validator() error {
 	if m.ComputeName == "" {
 		return fmt.Errorf("compute name must be supplied")
 	}
-	if m.WorkflowName == "" {
-		return fmt.Errorf("workflow name must be supplied")
-	}
 	if m.SourcePath == "" {
 		return fmt.Errorf("source path must be supplied")
 	}
 	if m.DestinationPath == "" {
 		return fmt.Errorf("destination path must be supplied")
-	}
-	if m.WorkflowNamespace == "" {
-		m.WorkflowNamespace = corev1.NamespaceDefault
 	}
 	if m.Slots < -1 {
 		return fmt.Errorf("slots must be -1 (defer to profile), 0 (disable), or a positive integer")
@@ -106,12 +92,6 @@ func (m *StatusRequest) Validator() error {
 
 	if m.RequestName == "" {
 		return fmt.Errorf("request name must be supplied")
-	}
-	if m.WorkflowName == "" {
-		return fmt.Errorf("workflow name must be supplied")
-	}
-	if m.WorkflowNamespace == "" {
-		m.WorkflowNamespace = corev1.NamespaceDefault
 	}
 
 	return nil

--- a/daemons/copy-offload/pkg/server/server.go
+++ b/daemons/copy-offload/pkg/server/server.go
@@ -129,11 +129,14 @@ func (user *UserHttp) GetRequest(w http.ResponseWriter, req *http.Request) {
 	// This is the v1.0 apiVersion input. See COPY_OFFLOAD_API_VERSION.
 	var statreq driver.StatusRequest
 	statreq.RequestName = requestName
-	statreq.WorkflowName = params.Get("workflowName")
-	statreq.WorkflowNamespace = params.Get("workflowNamespace")
 	statreq.MaxWaitSecs, err = strconv.Atoi(params.Get("maxWaitSecs"))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("unable to parse maxWaitSecs: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+	params.Del("maxWaitSecs")
+	if params.Encode() != "" {
+		http.Error(w, fmt.Sprintf("unexpected query parameters: %s", params.Encode()), http.StatusBadRequest)
 		return
 	}
 	if err := statreq.Validator(); err != nil {

--- a/daemons/copy-offload/pkg/server/server_test.go
+++ b/daemons/copy-offload/pkg/server/server_test.go
@@ -60,6 +60,8 @@ var derKeyAlg2 = []byte("")
 
 // Fill in the tokens/keys prior to running the tests.
 func TestMain(m *testing.M) {
+	os.Setenv("DW_WORKFLOW_NAME", "yellow")
+	os.Setenv("DW_WORKFLOW_NAMESPACE", "default")
 	err := createTokensAndKeys()
 	if err != nil {
 		fmt.Printf("%s\n", err.Error())
@@ -146,7 +148,11 @@ func setupLog() logr.Logger {
 
 func TestA_Hello(t *testing.T) {
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	t.Run("returns hello response", func(t *testing.T) {
@@ -198,7 +204,11 @@ func TestB_ListRequests(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	for _, test := range testCases {
@@ -235,7 +245,7 @@ func TestC_GetRequest(t *testing.T) {
 			name:        "returns status-ok",
 			method:      http.MethodGet,
 			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "workflowNamespace=default&workflowName=yellow&maxWaitSecs=10",
+			params:      "maxWaitSecs=10",
 			wantText:    "{\"state\":\"pending\",\"status\":\"unknown status\"}\n",
 			wantStatus:  http.StatusOK,
 		},
@@ -243,25 +253,17 @@ func TestC_GetRequest(t *testing.T) {
 			name:        "returns status-badr-request for maxWaitSecs",
 			method:      http.MethodGet,
 			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "workflowNamespace=default&workflowName=yellow",
+			params:      "",
 			wantText:    "unable to parse maxWaitSecs: strconv.Atoi: parsing \"\": invalid syntax\n",
 			wantStatus:  http.StatusBadRequest,
 		},
 		{
-			name:        "returns status-badr-request for requestName",
+			name:        "returns status-badr-request for extra params",
 			method:      http.MethodGet,
 			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "workflowNamespace=default&maxWaitSecs=10",
-			wantText:    "workflow name must be supplied\n",
+			params:      "maxWaitSecs=10&extra=1",
+			wantText:    "unexpected query parameters: extra=1\n",
 			wantStatus:  http.StatusBadRequest,
-		},
-		{
-			name:        "returns status-ok for empty workNamespace",
-			method:      http.MethodGet,
-			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "workflowName=yellow&maxWaitSecs=10",
-			wantText:    "{\"state\":\"pending\",\"status\":\"unknown status\"}\n",
-			wantStatus:  http.StatusOK,
 		},
 		{
 			name:       "returns status-not-implemented for POST",
@@ -278,7 +280,11 @@ func TestC_GetRequest(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	for _, test := range testCases {
@@ -330,7 +336,11 @@ func TestD_CancelRequest(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	for _, test := range testCases {
@@ -391,7 +401,11 @@ func TestE_TrialRequest(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	for _, test := range testCases {
@@ -452,7 +466,11 @@ func TestF_Lifecycle(t *testing.T) {
 	}
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	var listWanted []string
@@ -565,7 +583,11 @@ func TestF_Lifecycle(t *testing.T) {
 func TestG_BadAPIVersion(t *testing.T) {
 
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	testCases := []struct {
@@ -663,7 +685,11 @@ func TestG_BadAPIVersion(t *testing.T) {
 
 func TestH_BearerToken(t *testing.T) {
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	t.Run("accepts valid bearer token when using matching key", func(t *testing.T) {
@@ -692,7 +718,11 @@ func TestH_BearerToken(t *testing.T) {
 
 func TestI_BearerTokenNegatives(t *testing.T) {
 	crLog := setupLog()
-	drvr := driver.NewDriver(crLog, true)
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
 	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
 
 	t.Run("fails when bearer token is expected but is not correct", func(t *testing.T) {

--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -173,14 +173,6 @@ static int _copy_offload_configure(COPY_OFFLOAD *offload, int skip_tls) {
     if ((c = strchr(offload->server_port, ',')) != NULL) {
         *c = '\0';
     }
-    if ((offload->workflow_name = getenv(WORKFLOW_NAME_ENV)) == NULL) {
-        snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE-1, "Unable to get workflow name from environment variable %s\n", WORKFLOW_NAME_ENV);
-        return 1;
-    }
-    if ((offload->workflow_namespace = getenv(WORKFLOW_NAMESPACE_ENV)) == NULL) {
-        snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE-1, "Unable to get workflow namespace from environment variable %s\n", WORKFLOW_NAMESPACE_ENV);
-        return 1;
-    }
     // The token is optional, depending on how the server is configured.
     offload->token_buf = NULL;
     offload->token = getenv(WORKFLOW_TOKEN_ENV);
@@ -357,8 +349,8 @@ int copy_offload_status(COPY_OFFLOAD *offload, char *job_name, int max_wait_secs
     char parambuf[COPY_OFFLOAD_URL_SIZE];
 
     // This is the v1.0 apiVersion. See COPY_OFFLOAD_API_VERSION.
-    const char *offload_req_v1_0 = "workflowNamespace=%s&workflowName=%s&maxWaitSecs=%d";
-    n = snprintf(parambuf, sizeof(parambuf), offload_req_v1_0, offload->workflow_namespace, offload->workflow_name, max_wait_secs);
+    const char *offload_req_v1_0 = "maxWaitSecs=%d";
+    n = snprintf(parambuf, sizeof(parambuf), offload_req_v1_0, max_wait_secs);
     if (n >= (int)sizeof(parambuf)) {
         snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE, "Error formatting parameters: buffer too small");
         return ret;
@@ -484,8 +476,6 @@ int copy_offload_copy(COPY_OFFLOAD *offload, const char *profile_name, int slots
     // This is the v1.0 apiVersion. See COPY_OFFLOAD_API_VERSION.
     const char *offload_req_v1_0 =
         "{\"computeName\": \"%s\", "
-        "\"workflowName\": \"%s\", "
-        "\"workflowNamespace\": \"%s\", "
         "\"sourcePath\": \"%s\", "
         "\"destinationPath\": \"%s\", "
         "\"dmProfile\": \"%s\", "
@@ -495,7 +485,7 @@ int copy_offload_copy(COPY_OFFLOAD *offload, const char *profile_name, int slots
         "\"storeStdout\": false, "
         "\"slots\": %d, "
         "\"maxSlots\": %d}";
-    n = snprintf(postbuf, sizeof(postbuf), offload_req_v1_0, offload->my_host_name, offload->workflow_name, offload->workflow_namespace, source_path, dest_path, profile_name, dry_run_str, slots, max_slots);
+    n = snprintf(postbuf, sizeof(postbuf), offload_req_v1_0, offload->my_host_name, source_path, dest_path, profile_name, dry_run_str, slots, max_slots);
     if (n >= (int)sizeof(postbuf)) {
         snprintf(offload->err_message, COPY_OFFLOAD_MSG_SIZE, "Error formatting body: buffer too small");
         return ret;

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -29,12 +29,6 @@
 // The name of the environment variable that contains the workflow's token.
 #define WORKFLOW_TOKEN_ENV "DW_WORKFLOW_TOKEN"
 
-// The name of the environment variable that contains the workflow's name.
-#define WORKFLOW_NAME_ENV "DW_WORKFLOW_NAME"
-
-// The name of the environment variable that contains the workflow's namespace.
-#define WORKFLOW_NAMESPACE_ENV "DW_WORKFLOW_NAMESPACE"
-
 // The name of the environment variable that contains the name of the rabbit
 // that is running the MPI launcher, when MPI is being used.
 #define NNF_CONTAINER_LAUNCHER_ENV "NNF_CONTAINER_LAUNCHER"

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -50,6 +50,7 @@ void usage(const char **argv) {
     fprintf(stderr, "       -D DEST_PATH       Local path to destination.\n");
     fprintf(stderr, "       -m SLOTS           Number of slots (processes).\n");
     fprintf(stderr, "       -M MAX_SLOTS       Maximum number of slots (processes).\n");
+    fprintf(stderr, "       -C MY_HOSTNAME     Name of the host submitting the request. (for development/debugging)\n");
     fprintf(stderr, "       -d                 Perform a dry run.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Usage: %s [COMMON_ARGS] -S <ARGS>\n", argv[0]);
@@ -61,7 +62,6 @@ void usage(const char **argv) {
     fprintf(stderr, "    -v                  Request verbose output from this tool.\n");
     fprintf(stderr, "    -V                  Request verbose output from libcurl.\n");
     fprintf(stderr, "    -s                  Skip TLS configuration.\n");
-    fprintf(stderr, "    -C MY_HOSTNAME      Name of the host submitting the request. (for development/debugging)\n");
     fprintf(stderr, "    -t TOKEN_FILE       Bearer token file.\n");
     fprintf(stderr, "    -x CERT_FILE        CA/Server certificate file. A self-signed certificate.\n");
 }


### PR DESCRIPTION
Let the copy-offload server get the workflow name from the container env vars. The compute node app does not need to give it the name of the workflow.

