### PR TITLE
libcopyoffload: use json-c to parse the status response

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o nn
 ###############################################################################
 FROM builder_setup AS copy_offload_tester_builder
 
-RUN apk add curl-dev gcc libc-dev && \
+RUN apk add curl-dev gcc libc-dev json-c json-c-dev && \
     make -C ./daemons/lib-copy-offload tester
 
 ###############################################################################
@@ -100,7 +100,7 @@ COPY --from=shellchecker /workspace/shellcheck_okay shellcheck_okay
 ENV CGO_ENABLED=0
 
 # These are used by the e2e-mocked test for the copy-offload server.
-RUN apk add curl openssl
+RUN apk add curl openssl json-c
 
 ENTRYPOINT [ "make", "within-container-unit-test" ]
 

--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -144,6 +144,14 @@ if [[ $job1 != "mock-rabbit-01--nnf-copy-offload-node-0" ]]; then
 fi
 
 # shellcheck disable=SC2086
+if ! output=$($CO $CO_TLS_ARGS -q -j $job1); then
+    echo "line $LINENO output: $output"
+    cleanup
+fi
+echo "GETREQUEST:"
+echo "$output"
+
+# shellcheck disable=SC2086
 if ! output=$($CO $CO_TLS_ARGS -l); then
     echo "line $LINENO output: $output"
     cleanup

--- a/daemons/copy-offload/pkg/driver/dmresponse.go
+++ b/daemons/copy-offload/pkg/driver/dmresponse.go
@@ -19,8 +19,6 @@
 
 package driver
 
-import "fmt"
-
 type DataMovementStatusResponse_State string
 
 const (
@@ -72,23 +70,4 @@ type DataMovementStatusResponse_v1_0 struct {
 	StartTime string `json:"startTime,omitempty"`
 	// The end time (local) of the data movement operation
 	EndTime string `json:"endTime,omitempty"`
-}
-
-func (dmr *DataMovementStatusResponse_v1_0) String() error {
-	if dmr.State == "" {
-		return fmt.Errorf("State must be set")
-	}
-	if dmr.Status == "" {
-		return fmt.Errorf("Status must be set")
-	}
-	if dmr.CommandStatus == nil {
-		return fmt.Errorf("CommandStatus must be set")
-	}
-	if dmr.StartTime == "" {
-		return fmt.Errorf("StartTime must be set")
-	}
-	if dmr.EndTime == "" {
-		return fmt.Errorf("EndTime must be set")
-	}
-	return nil
 }

--- a/daemons/copy-offload/pkg/server/server.go
+++ b/daemons/copy-offload/pkg/server/server.go
@@ -156,7 +156,7 @@ func (user *UserHttp) GetRequest(w http.ResponseWriter, req *http.Request) {
 	}
 	if err != nil {
 		if http_code > 0 {
-			http.Error(w, fmt.Sprintf("%s\n", err.Error()), http_code)
+			http.Error(w, err.Error(), http_code)
 		} else {
 			http.Error(w, fmt.Sprintf("unable to get request: %s\n", err.Error()), http.StatusInternalServerError)
 		}
@@ -213,7 +213,7 @@ func (user *UserHttp) CancelRequest(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, fmt.Sprintf("unable to cancel request: %s", err.Error()), http.StatusNotFound)
 		return
 	}
-	http.Error(w, "", http.StatusNoContent)
+	// StatusOK is implied.
 }
 
 func (user *UserHttp) TrialRequest(w http.ResponseWriter, req *http.Request) {

--- a/daemons/copy-offload/pkg/server/server_test.go
+++ b/daemons/copy-offload/pkg/server/server_test.go
@@ -176,195 +176,7 @@ func TestA_Hello(t *testing.T) {
 	})
 }
 
-func TestB_ListRequests(t *testing.T) {
-	testCases := []struct {
-		name       string
-		method     string
-		wantText   string
-		wantStatus int
-	}{
-		{
-			name:       "returns status-no-content",
-			method:     http.MethodGet,
-			wantText:   "",
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:       "returns status-not-implemented for POST",
-			method:     http.MethodPost,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-		{
-			name:       "returns status-not-implemented for PUT",
-			method:     http.MethodPut,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-	}
-
-	crLog := setupLog()
-	drvr, err := driver.NewDriver(crLog, true)
-	if err != nil {
-		t.Errorf("NewDriver failed: %s", err.Error())
-		t.FailNow()
-	}
-	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			request, _ := http.NewRequest(test.method, "/list", nil)
-			request.Header.Set("Accepts-version", "1.0")
-			response := httptest.NewRecorder()
-
-			httpHandler.ListRequests(response, request)
-
-			res := response.Result()
-			got := response.Body.String()
-
-			if res.StatusCode != test.wantStatus {
-				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
-			}
-			if got != test.wantText {
-				t.Errorf("got %q, want %q", got, test.wantText)
-			}
-		})
-	}
-}
-
-func TestC_GetRequest(t *testing.T) {
-	testCases := []struct {
-		name        string
-		method      string
-		requestName string
-		params      string
-		wantText    string
-		wantStatus  int
-	}{
-		{
-			name:        "returns status-ok",
-			method:      http.MethodGet,
-			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "maxWaitSecs=10",
-			wantText:    "{\"state\":\"pending\",\"status\":\"unknown status\"}\n",
-			wantStatus:  http.StatusOK,
-		},
-		{
-			name:        "returns status-badr-request for maxWaitSecs",
-			method:      http.MethodGet,
-			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "",
-			wantText:    "unable to parse maxWaitSecs: strconv.Atoi: parsing \"\": invalid syntax\n",
-			wantStatus:  http.StatusBadRequest,
-		},
-		{
-			name:        "returns status-badr-request for extra params",
-			method:      http.MethodGet,
-			requestName: "nnf-copy-offload-node-9ae2a136-4",
-			params:      "maxWaitSecs=10&extra=1",
-			wantText:    "unexpected query parameters: extra=1\n",
-			wantStatus:  http.StatusBadRequest,
-		},
-		{
-			name:       "returns status-not-implemented for POST",
-			method:     http.MethodPost,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-		{
-			name:       "returns status-not-implemented for PUT",
-			method:     http.MethodPut,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-	}
-
-	crLog := setupLog()
-	drvr, err := driver.NewDriver(crLog, true)
-	if err != nil {
-		t.Errorf("NewDriver failed: %s", err.Error())
-		t.FailNow()
-	}
-	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			request, _ := http.NewRequest(test.method, fmt.Sprintf("/status/%s?%s", test.requestName, test.params), nil)
-			request.Header.Set("Accepts-version", "1.0")
-			response := httptest.NewRecorder()
-
-			httpHandler.GetRequest(response, request)
-
-			res := response.Result()
-			got := response.Body.String()
-
-			if res.StatusCode != test.wantStatus {
-				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
-			}
-			if got != test.wantText {
-				t.Errorf("got %q, want %q", got, test.wantText)
-			}
-		})
-	}
-}
-
-func TestD_CancelRequest(t *testing.T) {
-	testCases := []struct {
-		name       string
-		method     string
-		wantText   string
-		wantStatus int
-	}{
-		{
-			name:       "returns status-no-content",
-			method:     http.MethodDelete,
-			wantText:   "unable to cancel request: request not found\n",
-			wantStatus: http.StatusNotFound,
-		},
-		{
-			name:       "returns status-not-implemented for GET",
-			method:     http.MethodGet,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-		{
-			name:       "returns status-not-implemented for PUT",
-			method:     http.MethodPut,
-			wantText:   "method not supported\n",
-			wantStatus: http.StatusNotImplemented,
-		},
-	}
-
-	crLog := setupLog()
-	drvr, err := driver.NewDriver(crLog, true)
-	if err != nil {
-		t.Errorf("NewDriver failed: %s", err.Error())
-		t.FailNow()
-	}
-	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			request, _ := http.NewRequest(test.method, "/cancel/nnf-copy-offload-node-9ae2a136-4", nil)
-			request.Header.Set("Accepts-version", "1.0")
-			response := httptest.NewRecorder()
-
-			httpHandler.CancelRequest(response, request)
-
-			res := response.Result()
-			got := response.Body.String()
-
-			if res.StatusCode != test.wantStatus {
-				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
-			}
-			if got != test.wantText {
-				t.Errorf("got %q, want %q", got, test.wantText)
-			}
-		})
-	}
-}
-
-func TestE_TrialRequest(t *testing.T) {
+func TestB_TrialRequest(t *testing.T) {
 	testCases := []struct {
 		name       string
 		method     string
@@ -375,7 +187,7 @@ func TestE_TrialRequest(t *testing.T) {
 		{
 			name:       "returns status-ok",
 			method:     http.MethodPost,
-			body:       []byte("{\"computeName\": \"rabbit-compute-3\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:       []byte("{\"computeName\": \"rabbit-compute-3\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			wantText:   "name=mock-rabbit-01--nnf-copy-offload-node-0\n",
 			wantStatus: http.StatusOK,
 		},
@@ -433,6 +245,276 @@ func TestE_TrialRequest(t *testing.T) {
 	}
 }
 
+func makeOneRequest(t *testing.T, httpHandler *UserHttp) string {
+	body := []byte("{\"computeName\": \"rabbit-compute-3\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}")
+	readerBody := bytes.NewReader(body)
+	request, _ := http.NewRequest(http.MethodPost, "/trial", readerBody)
+	request.Header.Set("Accepts-version", "1.0")
+	response := httptest.NewRecorder()
+	httpHandler.TrialRequest(response, request)
+
+	res := response.Result()
+	got := response.Body.String()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("got status %d, want status %d", res.StatusCode, http.StatusOK)
+	}
+	wantText := "name=mock-rabbit-01--nnf-copy-offload-node-"
+	if !strings.HasPrefix(got, wantText) {
+		t.Errorf("got %q, want %q", got, wantText)
+	}
+	parts := strings.Split(got, "=")
+	return strings.TrimSuffix(parts[1], "\n")
+}
+
+func TestC_ListRequests(t *testing.T) {
+	testCases := []struct {
+		name        string
+		method      string
+		wantText    string
+		wantStatus  int
+		makeRequest bool
+	}{
+		{
+			name:        "returns status-no-content",
+			method:      http.MethodGet,
+			wantText:    "",
+			wantStatus:  http.StatusOK,
+			makeRequest: false,
+		},
+		{
+			name:        "returns status-not-implemented for POST",
+			method:      http.MethodPost,
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: false,
+		},
+		{
+			name:        "returns status-not-implemented for PUT",
+			method:      http.MethodPut,
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: false,
+		},
+		{
+			name:        "returns the list",
+			method:      http.MethodGet,
+			wantText:    "REQNAME\n",
+			wantStatus:  http.StatusOK,
+			makeRequest: true,
+		},
+	}
+
+	crLog := setupLog()
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
+	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			var reqName string
+			if test.makeRequest {
+				reqName = makeOneRequest(t, httpHandler)
+			}
+			request, _ := http.NewRequest(test.method, "/list", nil)
+			request.Header.Set("Accepts-version", "1.0")
+			response := httptest.NewRecorder()
+
+			httpHandler.ListRequests(response, request)
+
+			res := response.Result()
+			got := response.Body.String()
+
+			if res.StatusCode != test.wantStatus {
+				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
+			}
+			wantText := test.wantText
+			if reqName != "" {
+				wantText = strings.ReplaceAll(test.wantText, "REQNAME", reqName)
+			}
+			if got != wantText {
+				t.Errorf("got %q, want %q", got, wantText)
+			}
+		})
+	}
+}
+
+func TestD_GetRequest(t *testing.T) {
+	testCases := []struct {
+		name        string
+		method      string
+		requestName string
+		params      string
+		wantText    string
+		wantStatus  int
+		makeRequest bool
+	}{
+		{
+			name:        "returns status-ok",
+			method:      http.MethodGet,
+			requestName: "REQNAME",
+			params:      "maxWaitSecs=10",
+			wantText:    "{\"state\":\"running\",\"status\":\"unknown status\",\"commandStatus\":{\"command\":\"/bin/bash -c true\"},\"startTime\":\"2025-04-01 11:46:36.535519 -0500 CDT\"}\n",
+			wantStatus:  http.StatusOK,
+			makeRequest: true,
+		},
+		{
+			name:        "returns status-not-found for unknown request",
+			method:      http.MethodGet,
+			requestName: "unknown-request",
+			params:      "maxWaitSecs=10",
+			wantText:    "request not found\n",
+			wantStatus:  http.StatusNotFound,
+			makeRequest: false,
+		},
+		{
+			name:        "returns status-badr-request for maxWaitSecs",
+			method:      http.MethodGet,
+			requestName: "REQNAME-nonesuch",
+			params:      "",
+			wantText:    "unable to parse maxWaitSecs: strconv.Atoi: parsing \"\": invalid syntax\n",
+			wantStatus:  http.StatusBadRequest,
+			makeRequest: true,
+		},
+		{
+			name:        "returns status-badr-request for extra params",
+			method:      http.MethodGet,
+			requestName: "REQNAME",
+			params:      "maxWaitSecs=10&extra=1",
+			wantText:    "unexpected query parameters: extra=1\n",
+			wantStatus:  http.StatusBadRequest,
+			makeRequest: true,
+		},
+		{
+			name:        "returns status-not-implemented for POST",
+			method:      http.MethodPost,
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: true,
+		},
+		{
+			name:        "returns status-not-implemented for PUT",
+			method:      http.MethodPut,
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: true,
+		},
+	}
+
+	crLog := setupLog()
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
+	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reqName := test.requestName
+			if test.makeRequest {
+				name := makeOneRequest(t, httpHandler)
+				reqName = strings.ReplaceAll(test.requestName, "REQNAME", name)
+			}
+			request, _ := http.NewRequest(test.method, fmt.Sprintf("/status/%s?%s", reqName, test.params), nil)
+			request.Header.Set("Accepts-version", "1.0")
+			response := httptest.NewRecorder()
+
+			httpHandler.GetRequest(response, request)
+
+			res := response.Result()
+			got := response.Body.String()
+
+			if res.StatusCode != test.wantStatus {
+				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
+			}
+			if got != test.wantText {
+				t.Errorf("got %q, want %q", got, test.wantText)
+			}
+		})
+	}
+}
+
+func TestE_CancelRequest(t *testing.T) {
+	testCases := []struct {
+		name        string
+		method      string
+		requestName string
+		wantText    string
+		wantStatus  int
+		makeRequest bool
+	}{
+		{
+			name:        "returns status-no-content",
+			method:      http.MethodDelete,
+			requestName: "unknown-request-1",
+			wantText:    "unable to cancel request: request not found\n",
+			wantStatus:  http.StatusNotFound,
+			makeRequest: false,
+		},
+		{
+			name:        "returns status-ok",
+			method:      http.MethodDelete,
+			requestName: "REQNAME",
+			wantText:    "",
+			wantStatus:  http.StatusOK,
+			makeRequest: true,
+		},
+		{
+			name:        "returns status-not-implemented for GET",
+			method:      http.MethodGet,
+			requestName: "unknown-request-2",
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: false,
+		},
+		{
+			name:        "returns status-not-implemented for PUT",
+			method:      http.MethodPut,
+			requestName: "unknown-request-3",
+			wantText:    "method not supported\n",
+			wantStatus:  http.StatusNotImplemented,
+			makeRequest: false,
+		},
+	}
+
+	crLog := setupLog()
+	drvr, err := driver.NewDriver(crLog, true)
+	if err != nil {
+		t.Errorf("NewDriver failed: %s", err.Error())
+		t.FailNow()
+	}
+	httpHandler := &UserHttp{Log: crLog, Drvr: drvr, Mock: true}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reqName := test.requestName
+			if test.makeRequest {
+				name := makeOneRequest(t, httpHandler)
+				reqName = strings.ReplaceAll(test.requestName, "REQNAME", name)
+			}
+			request, _ := http.NewRequest(test.method, fmt.Sprintf("/cancel/%s", reqName), nil)
+			request.Header.Set("Accepts-version", "1.0")
+			response := httptest.NewRecorder()
+
+			httpHandler.CancelRequest(response, request)
+
+			res := response.Result()
+			got := response.Body.String()
+
+			if res.StatusCode != test.wantStatus {
+				t.Errorf("got status %d, want status %d", res.StatusCode, test.wantStatus)
+			}
+			if got != test.wantText {
+				t.Errorf("got %q, want %q", got, test.wantText)
+			}
+		})
+	}
+}
+
 func TestF_Lifecycle(t *testing.T) {
 
 	scheduleJobs := []struct {
@@ -445,21 +527,21 @@ func TestF_Lifecycle(t *testing.T) {
 		{
 			name:       "schedule job 1",
 			method:     http.MethodPost,
-			body:       []byte("{\"computeName\": \"rabbit-compute-3\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:       []byte("{\"computeName\": \"rabbit-compute-3\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			wantText:   "name=mock-rabbit-01--nnf-copy-offload-node-0\n",
 			wantStatus: http.StatusOK,
 		},
 		{
 			name:       "schedule job 2",
 			method:     http.MethodPost,
-			body:       []byte("{\"computeName\": \"rabbit-compute-4\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:       []byte("{\"computeName\": \"rabbit-compute-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			wantText:   "name=mock-rabbit-01--nnf-copy-offload-node-1\n",
 			wantStatus: http.StatusOK,
 		},
 		{
 			name:       "schedule job 3",
 			method:     http.MethodPost,
-			body:       []byte("{\"computeName\": \"rabbit-compute-5\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:       []byte("{\"computeName\": \"rabbit-compute-5\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			wantText:   "name=mock-rabbit-01--nnf-copy-offload-node-2\n",
 			wantStatus: http.StatusOK,
 		},
@@ -536,11 +618,12 @@ func TestF_Lifecycle(t *testing.T) {
 		res := response.Result()
 		got := response.Body.String()
 
-		if res.StatusCode != http.StatusNoContent {
-			t.Errorf("got status %d, want status %d", res.StatusCode, http.StatusNoContent)
+		if res.StatusCode != http.StatusOK {
+			t.Errorf("got status %d, want status %d", res.StatusCode, http.StatusOK)
 		}
-		if got != "\n" {
-			t.Errorf("got %q, want %q", got, "(newline)")
+		want := ""
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	})
 
@@ -641,14 +724,14 @@ func TestG_BadAPIVersion(t *testing.T) {
 			name:    "bad api version for copy",
 			method:  http.MethodPost,
 			url:     "/trial",
-			body:    []byte("{\"computeName\": \"rabbit-compute-3\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:    []byte("{\"computeName\": \"rabbit-compute-3\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			handler: httpHandler.TrialRequest,
 		},
 		{
 			name:           "skip api version for copy",
 			method:         http.MethodPost,
 			url:            "/trial",
-			body:           []byte("{\"computeName\": \"rabbit-compute-3\", \"workflowName\": \"nnf-copy-offload-node-9ae2a136-4\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
+			body:           []byte("{\"computeName\": \"rabbit-compute-3\", \"sourcePath\": \"/mnt/nnf/dc51a384-99bd-4ef1-8444-4ee3b0cdc8a8-0\", \"destinationPath\": \"/lus/global/dean/foo\", \"dryrun\": true}"),
 			handler:        httpHandler.TrialRequest,
 			skipApiVersion: true,
 		},

--- a/daemons/lib-copy-offload/Makefile
+++ b/daemons/lib-copy-offload/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -17,21 +17,28 @@
 
 CC ?= /usr/bin/gcc
 AR ?= /usr/bin/ar
-CFLAGS = -Wall -Werror -g `pkg-config --cflags libcurl`
-LDFLAGS = `pkg-config --libs libcurl`
+CFLAGS = -Wall -Werror -g `pkg-config --cflags libcurl json-c`
+LDFLAGS = `pkg-config --libs libcurl json-c`
 ARFLAGS = rcs
 
-all: libcopyoffload.a tester
+.PHONY: all
+all: lib-dependencies libcopyoffload.a tester
 
-libcopyoffload.a: copy-offload.o
-	$(AR) $(ARFLAGS) libcopyoffload.a copy-offload.o
+.PHONY: lib-dependencies
+lib-dependencies:
+	@ pkg-config --libs libcurl json-c > /dev/null || echo "On a Mac use 'brew install json-c' and on a Linux node 'dnf install json-c json-c-devel'."
+
+libcopyoffload.a: copy-offload.o copy-offload-status.o
+	$(AR) $(ARFLAGS) libcopyoffload.a copy-offload.o copy-offload-status.o
 
 tester: test-tool/main.o libcopyoffload.a
 	$(CC) $(CFLAGS) -o tester test-tool/main.o -L. -lcopyoffload $(LDFLAGS)
 
 test-tool/main.o: test-tool/main.c copy-offload.h
-copy-offload.o: copy-offload.c copy-offload.h
+copy-offload.o: copy-offload.c copy-offload.h copy-offload-status.c
+copy-offload-status.o: copy-offload-status.c copy-offload.h
 
+.PHONY: clean
 clean:
 	rm -f *.o core tester *.a
 	rm -f test-tool/*.o

--- a/daemons/lib-copy-offload/Readme.md
+++ b/daemons/lib-copy-offload/Readme.md
@@ -3,3 +3,5 @@
 The copy-offload API allows a user's compute application to specify data movement requests to the [copy-offload server](https://nearnodeflash.github.io/dev/guides/data-movement/copy-offload/). The user's application utilizes the `libcopyoffload` library to establish a secure connection to the copy-offload server to initiate, list, query the status of, or cancel data movement requests.
 
 See [copy-offload.h](./copy-offload.h) for the API description. See the [test tool](./test-tool/main.c) for examples of using the API.
+
+The build environment requires libraries and headers for `libcurl` and `json-c`. On a Mac run `brew install json-c`, and on a Redhat Linux machine `dnf install json-c json-c-devel`.

--- a/daemons/lib-copy-offload/copy-offload-status.c
+++ b/daemons/lib-copy-offload/copy-offload-status.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include "copy-offload-status.h"
+
+copy_offload_status_response_t *_copy_offload_status_parse(char *json_text) {
+
+    copy_offload_status_response_t *response = (copy_offload_status_response_t *)calloc(1, sizeof(struct copy_offload_status_response_s));
+    json_object *root = json_tokener_parse(json_text);
+
+    // Used for memory management. All of the @response field pointers are
+    // pointing into this object.
+    response->_root = root;
+    
+    //printf("The json string:\n\n%s\n\n", json_object_to_json_string(root));
+    
+    json_object *object;
+    if (json_object_object_get_ex(root, "state", &object)) {
+        if (object != NULL) {
+            response->state = json_object_get_string(object);
+        }
+    }
+    if (json_object_object_get_ex(root, "status", &object)) {
+        if (object != NULL) {
+            response->status = json_object_get_string(object);
+        }
+    }
+    if (json_object_object_get_ex(root, "message", &object)) {
+        if (object != NULL) {
+            response->message = json_object_get_string(object);
+        }
+    }
+    if (json_object_object_get_ex(root, "startTime", &object)) {
+        if (object != NULL) {
+            response->start_time = json_object_get_string(object);
+        }
+    }
+    if (json_object_object_get_ex(root, "endTime", &object)) {
+        if (object != NULL) {
+            response->end_time = json_object_get_string(object);
+        }
+    }
+
+    json_object *cmd_object;
+    if (json_object_object_get_ex(root, "commandStatus", &cmd_object)) {
+        if (json_object_object_get_ex(cmd_object, "command", &object)) {
+            if (object != NULL) {
+                response->command_status.command = json_object_get_string(object);
+            }
+        }
+        if (json_object_object_get_ex(cmd_object, "progress", &object)) {
+            if (object != NULL) {
+                response->command_status.progress = json_object_get_int(object);
+            }
+        }
+        if (json_object_object_get_ex(cmd_object, "elapsedTime", &object)) {
+            if (object != NULL) {
+                response->command_status.elapsed_time = json_object_get_string(object);
+            }
+        }
+        if (json_object_object_get_ex(cmd_object, "lastMessage", &object)) {
+            if (object != NULL) {
+                response->command_status.last_message = json_object_get_string(object);
+            }
+        }
+        if (json_object_object_get_ex(cmd_object, "lastMessageTime", &object)) {
+            if (object != NULL) {
+                response->command_status.last_message_time = json_object_get_string(object);
+            }
+        }
+    }
+
+    return response;
+}
+
+/* Pretty-print the response record to the given file descriptor.
+ */
+void copy_offload_status_pretty_print(FILE *out, copy_offload_status_response_t *response) {
+    if (response == NULL || response->_root == NULL) {
+        fprintf(out, "The response object is empty.\n");
+        return;
+    }
+
+    fprintf(out,
+        "state: %s\n"
+        "status: %s\n"
+        "message: %s\n"
+        "command: %s\n"
+        "progress: %d\n"
+        "elapsed time: %s\n"
+        "last message: %s\n"
+        "last message time: %s\n"
+        "start time: %s\n"
+        "end time: %s\n",
+        response->state, response->status, response->message,
+        response->command_status.command, response->command_status.progress,
+        response->command_status.elapsed_time, response->command_status.last_message,
+        response->command_status.last_message_time,
+        response->start_time, response->end_time);
+}
+
+/* Cleanup the memory behind the @reponse object and its backing json object.
+ * After this has been called it is no longer safe to reference anything in
+ * the @response object.
+ */
+void copy_offload_status_cleanup(copy_offload_status_response_t *response) {
+    if (response != NULL && response->_root != NULL) {
+        json_object_put(response->_root);
+        response->_root = NULL;
+    }
+}

--- a/daemons/lib-copy-offload/copy-offload-status.h
+++ b/daemons/lib-copy-offload/copy-offload-status.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <json-c/json.h>
+
+/* The results as returned by copy_offload_status().
+ */
+
+// Data movement operations contain a CommandStatus in the Status object.
+// This information relays the current state of the data movement progress.
+struct _copy_offload_command_status_s {
+    // Command used to perform Data Movement
+    const char *command;
+    // Progress percentage (0-100%) of the data movement based on the output of `dcp`. `dcp` must be present in the command.
+    int   progress;
+	// Duration of how long the operation has been running (e.g. 1m30s)
+    const char *elapsed_time;
+	// The most recent line of output from the data movement command
+    const char *last_message;
+	// The time (local) of lastMessage
+    const char *last_message_time;
+};
+
+// The Data Movement Status Response message defines the current status of a
+// data movement request.
+// This is the v1.0 apiVersion. See COPY_OFFLOAD_API_VERSION.
+struct copy_offload_status_response_s {
+    json_object *_root;
+    // Current state of the Data Movement Request
+    const char *state;
+	// Current status of the Data Movement Request
+    const char *status;
+	// Any extra information supplied with the state/status
+    const char *message;
+    // Current state/progress of the Data Movement command
+    struct _copy_offload_command_status_s command_status;
+	// The start time (local) of the data movement operation
+    const char *start_time;
+	// The end time (local) of the data movement operation
+    const char *end_time;
+};
+typedef struct copy_offload_status_response_s copy_offload_status_response_t;
+
+copy_offload_status_response_t *_copy_offload_status_parse(char *json_text);

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -18,6 +18,7 @@
  */
 
 #include <curl/curl.h>
+#include "copy-offload-status.h"
 
 // Define the API version. This applies to the request format sent by the client
 // as well as the response format sent by the server.
@@ -105,11 +106,18 @@ int copy_offload_list(COPY_OFFLOAD *offload, char **output);
  * The maximum number of seconds to wait for the job to complete is @max_wait_secs.
  * If @max_wait_secs is 0, then the server will return immediately. If it is -1, then
  * the server will wait indefinitely.
- * The caller is responsible for calling free() on @output if *output is non-NULL.
+ * The caller is responsible for calling copy_offload_status_cleanup() on
+ * @status_response if *status_response is non-NULL.
  * Returns 0 on success.
  * On failure it returns 1 and places an error message in @offload->err_message. 
  */
-int copy_offload_status(COPY_OFFLOAD *offload, char *job_name, int max_wait_secs, char **output);
+int copy_offload_status(COPY_OFFLOAD *offload, char *job_name, int max_wait_secs, copy_offload_status_response_t **status_response);
+void copy_offload_status_cleanup(copy_offload_status_response_t *status_response);
+
+/* Pretty-print the response record from copy_offload_status() to the given file
+ * descriptor.
+ */
+void copy_offload_status_pretty_print(FILE *out, copy_offload_status_response_t *status_response);
 
 /* Cancel a specific copy-offload request. The @job_name is the value returned
  * by copy_offload_copy().

--- a/daemons/lib-copy-offload/test-tool/Dockerfile.kind
+++ b/daemons/lib-copy-offload/test-tool/Dockerfile.kind
@@ -1,4 +1,4 @@
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -21,6 +21,10 @@ WORKDIR /workspace
 
 COPY daemons/lib-copy-offload daemons/lib-copy-offload/
 COPY Makefile Makefile
+
+RUN wget http://http.us.debian.org/debian/pool/main/j/json-c/libjson-c-dev_0.16-2_arm64.deb && \
+    wget http://http.us.debian.org/debian/pool/main/j/json-c/libjson-c5_0.16-2_arm64.deb && \
+    apt-get install ./libjson-c-dev_0.16-2_arm64.deb ./libjson-c5_0.16-2_arm64.deb
 
 RUN CC=gcc make -C ./daemons/lib-copy-offload tester
 

--- a/daemons/lib-copy-offload/test-tool/Dockerfile.rocky
+++ b/daemons/lib-copy-offload/test-tool/Dockerfile.rocky
@@ -1,4 +1,4 @@
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -21,7 +21,7 @@ FROM rockylinux/rockylinux:8.10 AS builder
 WORKDIR /workspace
 
 RUN dnf install -y \
-    make gcc libcurl-devel
+    make gcc libcurl-devel json-c json-c-devel
 
 COPY daemons/lib-copy-offload daemons/lib-copy-offload/
 COPY Makefile Makefile

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -94,6 +94,7 @@ int main(int argc, const char **argv) {
     int q_opt = 0;
     int max_wait_secs = 0;
     int ret;
+    copy_offload_status_response_t *status_response = NULL;
 
     while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:P:S:D:m:M:dHqj:w:")) != -1) {
         switch (c) {
@@ -224,7 +225,7 @@ int main(int argc, const char **argv) {
     } else if (H_opt) {
         ret = copy_offload_hello(offload, &output);
     } else if (q_opt) {
-        ret = copy_offload_status(offload, job_name, max_wait_secs, &output);
+        ret = copy_offload_status(offload, job_name, max_wait_secs, &status_response);
     } else {
         fprintf(stderr, "What action?\n");
         copy_offload_cleanup(offload);
@@ -235,6 +236,9 @@ int main(int argc, const char **argv) {
         printf("%s\n", output);
         free(output);
         output = NULL;
+    } else if (q_opt && status_response != NULL) {
+        copy_offload_status_pretty_print(stdout, status_response);
+        copy_offload_status_cleanup(status_response);
     }
 
     if (verbose) {

--- a/tools/mk-usercontainer-secrets.sh
+++ b/tools/mk-usercontainer-secrets.sh
@@ -64,7 +64,7 @@ set -o pipefail
 # =============
 # =============
 #
-#       A copy of this is in the argocd-boilerplate repo.
+#       A copy of this is in both the nnf-dm and the argocd-boilerplate repos.
 #
 #       Update the two copies together.
 #


### PR DESCRIPTION
Add the json-c library to the build env. Use it in libcopyoffload to parse the status response from the server.

Change the response for a cancel request to return StatusOK rather than StatusNoContent.

In server_test.go, fix some tests that were incorrect but silent. Allow some positive tests in some sections that had only negative tests. Add a section for the status request.