### PR TITLE
Add a shared-library build of libcopyoffload

### DIFF
--- a/daemons/lib-copy-offload/Makefile
+++ b/daemons/lib-copy-offload/Makefile
@@ -29,10 +29,10 @@ lib-dependencies:
 	@ pkg-config --libs libcurl json-c > /dev/null || echo "On a Mac use 'brew install json-c' and on a Linux node 'dnf install json-c json-c-devel'."
 
 libcopyoffload.a: copy-offload.o copy-offload-status.o
-	$(AR) $(ARFLAGS) libcopyoffload.a copy-offload.o copy-offload-status.o
+	$(AR) $(ARFLAGS) $@ $^
 
 tester: test-tool/main.o libcopyoffload.a
-	$(CC) $(CFLAGS) -o tester test-tool/main.o -L. -lcopyoffload $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $< -L. -lcopyoffload $(LDFLAGS)
 
 test-tool/main.o: test-tool/main.c copy-offload.h
 copy-offload.o: copy-offload.c copy-offload.h copy-offload-status.c

--- a/daemons/lib-copy-offload/Makefile
+++ b/daemons/lib-copy-offload/Makefile
@@ -17,12 +17,12 @@
 
 CC ?= /usr/bin/gcc
 AR ?= /usr/bin/ar
-CFLAGS = -Wall -Werror -g `pkg-config --cflags libcurl json-c`
+CFLAGS = -fPIC -Wall -Werror -g `pkg-config --cflags libcurl json-c`
 LDFLAGS = `pkg-config --libs libcurl json-c`
 ARFLAGS = rcs
 
 .PHONY: all
-all: lib-dependencies libcopyoffload.a tester
+all: lib-dependencies libcopyoffload.a libcopyoffload.so tester tester-dynamic
 
 .PHONY: lib-dependencies
 lib-dependencies:
@@ -31,8 +31,14 @@ lib-dependencies:
 libcopyoffload.a: copy-offload.o copy-offload-status.o
 	$(AR) $(ARFLAGS) $@ $^
 
+libcopyoffload.so: copy-offload.o copy-offload-status.o
+	$(CC) -shared $(CFLAGS) -o $@ $(LDFLAGS) $^
+
 tester: test-tool/main.o libcopyoffload.a
-	$(CC) $(CFLAGS) -o $@ $< -L. -lcopyoffload $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $< -L. -l:libcopyoffload.a $(LDFLAGS)
+
+tester-dynamic: test-tool/main.o libcopyoffload.so
+	$(CC) $(CFLAGS) -o $@ $< -L. -lcopyoffload
 
 test-tool/main.o: test-tool/main.c copy-offload.h
 copy-offload.o: copy-offload.c copy-offload.h copy-offload-status.c
@@ -40,5 +46,5 @@ copy-offload-status.o: copy-offload-status.c copy-offload.h
 
 .PHONY: clean
 clean:
-	rm -f *.o core tester *.a
+	rm -f *.o core tester tester-dynamic *.a *.so
 	rm -f test-tool/*.o

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -26,8 +26,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <curl/curl.h>
-
 #include "../copy-offload.h"
 
 /*


### PR DESCRIPTION
Build of libcopyoffload.so, the shared-library version of libcopyoffload.

Drop an unused header from the tester program.

Move to using make's automatic variables in the lib-copy-offload Makefile.
