### PR TITLE
copy-offload: Add shutdown request

### DIFF
--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -214,8 +214,25 @@ fi
 
 echo
 echo "PASS: Success"
-echo "Kill server $srvr_pid"
-kill "$srvr_pid"
+echo "Requesting server shutdown"
+
+# Send shutdown request
+# shellcheck disable=SC2086
+if ! output=$($CO $CO_TLS_ARGS -X); then
+    echo "line $LINENO output: $output"
+    cleanup
+fi
+echo "Shutdown response: $output"
+
+# Wait for the server to exit
+wait "$srvr_pid"
+server_exit_code=$?
+
+if [[ $server_exit_code -ne 0 ]]; then
+    echo "FAIL: Server did not exit cleanly (exit code $server_exit_code)"
+    exit 1
+fi
+
 if [[ -d $CERTDIR ]]; then
     rm -rf "$CERTDIR"
 fi

--- a/daemons/copy-offload/cmd/main.go
+++ b/daemons/copy-offload/cmd/main.go
@@ -197,12 +197,14 @@ func main() {
 	mux.HandleFunc("/cancel/", httpHandler.CancelRequest)
 	mux.HandleFunc("/list", httpHandler.ListRequests)
 	mux.HandleFunc("/status/", httpHandler.GetRequest)
+	mux.HandleFunc("/shutdown", httpHandler.ShutdownRequest)
 
 	srv := &http.Server{
 		Addr:      *addr,
 		Handler:   mux,
 		TLSConfig: tlsConfig,
 	}
+	httpHandler.Server = srv
 
 	if !skipTls {
 		err = srv.ListenAndServeTLS("", "")

--- a/daemons/lib-copy-offload/copy-offload.h
+++ b/daemons/lib-copy-offload/copy-offload.h
@@ -128,6 +128,9 @@ void copy_offload_status_pretty_print(FILE *out, copy_offload_status_response_t 
  */
 int copy_offload_cancel(COPY_OFFLOAD *offload, char *job_name, char **output);
 
+/* Shutdown the server and exit cleanly. */
+int copy_offload_shutdown(COPY_OFFLOAD *offload);
+
 /* Clean up the handle's resources. */
 void copy_offload_cleanup(COPY_OFFLOAD *offload);
 

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -56,6 +56,8 @@ void usage(const char **argv) {
     fprintf(stderr, "       -j JOB_NAME    The job name returned by the copy-offload request.\n");
     fprintf(stderr, "       -w MAX_WAIT    Maximum number of seconds to wait for the job to complete. (default 0)\n");
     fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: %s [COMMON_ARGS] -X\n", argv[0]);
+    fprintf(stderr, "    -X     Shutdown the copy-offload server.\n");
     fprintf(stderr, "COMMON_ARGS\n");
     fprintf(stderr, "    -v                  Request verbose output from this tool.\n");
     fprintf(stderr, "    -V                  Request verbose output from libcurl.\n");
@@ -90,11 +92,12 @@ int main(int argc, const char **argv) {
     int max_slots = -1;
     int H_opt = 0;
     int q_opt = 0;
+    int X_opt = 0;
     int max_wait_secs = 0;
     int ret;
     copy_offload_status_response_t *status_response = NULL;
 
-    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:P:S:D:m:M:dHqj:w:")) != -1) {
+    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:P:S:D:m:M:dHqj:w:X")) != -1) {
         switch (c) {
             case 'c':
                 c_opt = 1;
@@ -153,6 +156,9 @@ int main(int argc, const char **argv) {
                 break;
             case 'w':
                 max_wait_secs = atoi(optarg);
+                break;
+            case 'X':
+                X_opt = 1;
                 break;
             default:
                 usage(argv);
@@ -224,6 +230,8 @@ int main(int argc, const char **argv) {
         ret = copy_offload_hello(offload, &output);
     } else if (q_opt) {
         ret = copy_offload_status(offload, job_name, max_wait_secs, &status_response);
+    } else if (X_opt) {
+        ret = copy_offload_shutdown(offload);
     } else {
         fprintf(stderr, "What action?\n");
         copy_offload_cleanup(offload);


### PR DESCRIPTION
Add a `/shutdown` endpoint that shuts down the server cleanly.

If there are any requests in progress, the server will return a 409 Conflict. The user must monitor the requests and keep sending shutdown requests until the server is successful.