### PR TITLE
Regenerate stale TLS certs when secrets are missing from cluster

### DIFF
--- a/tools/mk-usercontainer-secrets.sh
+++ b/tools/mk-usercontainer-secrets.sh
@@ -163,6 +163,17 @@ create_secrets() {
         echo "The user-container secrets already exist in the cluster."
         exit 0
     fi
+
+    # The secrets don't exist in the cluster. If stale cert files remain on
+    # disk from a previous run (e.g. after a kind cluster reset), remove them
+    # so generate_certs() produces a fresh key pair with the current SANs.
+    if [[ -e "$CERTDIR" ]]; then
+        echo "Removing stale cert directory $CERTDIR (secrets not in cluster)."
+        rm -rf "$CERTDIR"
+    fi
+
+    generate_certs
+
     if ! kubectl create secret tls $SERVER_SECRET_TLS --cert "$SERVER_CERT" --key "$CA_KEY"; then
         echo "Unable to create the $SERVER_SECRET_TLS secret."
         exit 1
@@ -176,9 +187,10 @@ create_secrets() {
     fi
 }
 
-generate_certs
 if [[ -n $CREATE_SECRETS ]]; then
     create_secrets
+else
+    generate_certs
 fi
 exit 0
 


### PR DESCRIPTION
After a kind cluster reset, the K8s secrets are destroyed but the cert files on disk (in the `certs/` directory) persist. The `generate_certs()` function skips regeneration when it finds existing files, so `create_secrets()` would upload stale certs whose SANs may not match the current SystemConfiguration. This causes TLS handshake failures (`tls: bad certificate`) when the nnf-sos operator sends shutdown requests to copy-offload containers.

Fix this by having `create_secrets()` remove stale on-disk cert files when the secrets don't exist in the cluster, ensuring fresh certs are always generated with the correct SANs.