### PR TITLE
Add libcopyoffload man pages

### DIFF
--- a/man/man3/copy_offload_cancel.3
+++ b/man/man3/copy_offload_cancel.3
@@ -1,0 +1,175 @@
+.TH COPY_OFFLOAD_CANCEL 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_cancel \- cancel a running copy-offload job
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_cancel(COPY_OFFLOAD *" offload ", char *" job_name ,
+.BI "                        char **" output );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_cancel ()
+function requests cancellation of an active copy-offload job on the server. The
+function sends an HTTP DELETE request to the server's /cancel/{job_name} endpoint.
+.PP
+Cancellation is asynchronous. The function returns immediately after submitting
+the cancellation request, but the actual job termination may take some time
+depending on the data movement tool and current operation.
+.SS Parameters
+.TP
+.I offload
+Handle initialized and configured for server communication.
+.TP
+.I job_name
+Job identifier to cancel, as returned by
+.BR copy_offload_copy (3).
+.TP
+.I output
+Pointer to a char* that will receive any response message from the server. The
+caller is responsible for calling
+.BR free (3)
+on this string if it is non-NULL. The server may return confirmation text or
+error details.
+.SS Cancellation Behavior
+When a job is cancelled:
+.IP \(bu 3
+The server sends a termination signal to the data movement process
+.IP \(bu
+The job state transitions to "Cancelled" or "Error"
+.IP \(bu
+Partial data may exist at the destination
+.IP \(bu
+The job remains queryable via
+.BR copy_offload_status (3)
+until it expires
+.PP
+Jobs in different states respond to cancellation differently:
+.IP \(bu 3
+Queued jobs are removed immediately
+.IP \(bu
+Starting jobs are terminated during initialization
+.IP \(bu
+Running jobs are signaled to stop, may complete current file
+.IP \(bu
+Completed jobs cannot be cancelled (will return an error)
+.SH RETURN VALUE
+Returns 0 on success. On success,
+.I *output
+may contain a confirmation message from the server that must be freed by the caller.
+.PP
+Returns 1 on failure. On failure,
+.I offload->err_message
+contains an error description. The
+.I offload->http_code
+field indicates the HTTP status code.
+.PP
+Common HTTP response codes:
+.IP \(bu 3
+200 - Success, job cancellation initiated
+.IP \(bu
+404 - Job not found (invalid job_name or already expired)
+.IP \(bu
+400 - Bad request (job already completed)
+.IP \(bu
+401 - Unauthorized (invalid bearer token)
+.IP \(bu
+500 - Server error
+.SH ERRORS
+Error messages are stored in
+.IR offload->err_message .
+Common errors:
+.IP \(bu 3
+"Error formatting request: buffer too small" - Job name too long
+.IP \(bu
+libcurl errors - Network or connection failures
+.IP \(bu
+HTTP 404 - Job not found
+.IP \(bu
+HTTP 400 - Job cannot be cancelled (wrong state)
+.PP
+This function does not set
+.IR errno .
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_cancel ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+Thread-safe if each thread uses its own COPY_OFFLOAD handle.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_name = NULL;
+    char *response = NULL;
+    int ret;
+
+    handle = copy_offload_init();
+    copy_offload_configure(handle);
+
+    /* Submit a job */
+    ret = copy_offload_copy(handle, NULL, 4, 8, 0,
+                            "/source/large-data",
+                            "/dest/large-data",
+                            &job_name);
+    if (ret != 0) {
+        fprintf(stderr, "Copy submission failed\\n");
+        return 1;
+    }
+
+    printf("Job submitted: %s\\n", job_name);
+    sleep(2);  /* Let it start */
+
+    /* Cancel the job */
+    ret = copy_offload_cancel(handle, job_name, &response);
+    if (ret != 0) {
+        fprintf(stderr, "Cancel failed: %s (HTTP %ld)\\n",
+                handle->err_message, handle->http_code);
+    } else {
+        printf("Cancellation requested\\n");
+        if (response) {
+            printf("Server response: %s\\n", response);
+            free(response);
+        }
+    }
+
+    free(job_name);
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+Cancellation is asynchronous; the job may not stop immediately
+.IP \(bu
+Partial data may remain at the destination after cancellation
+.IP \(bu
+Use
+.BR copy_offload_status (3)
+after cancellation to confirm termination
+.IP \(bu
+Attempting to cancel an already completed job returns an error
+.IP \(bu
+The job remains queryable until it expires from the server cache
+.IP \(bu
+Cannot cancel jobs that were submitted by a different workflow token
+.SH SEE ALSO
+.BR copy_offload_copy (3),
+.BR copy_offload_status (3),
+.BR copy_offload_list (3),
+.BR free (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_cleanup.3
+++ b/man/man3/copy_offload_cleanup.3
@@ -1,0 +1,166 @@
+.TH COPY_OFFLOAD_CLEANUP 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_cleanup \- free resources associated with a handle
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "void copy_offload_cleanup(COPY_OFFLOAD *" offload );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_cleanup ()
+function frees all resources associated with a COPY_OFFLOAD handle created by
+.BR copy_offload_init (3).
+This includes libcurl handles, allocated buffers, and internal state.
+.PP
+After calling this function, the handle is no longer valid and must not be used
+for any operations. Attempting to use a cleaned-up handle results in undefined
+behavior.
+.PP
+The function performs the following cleanup:
+.IP \(bu 3
+Frees the bearer token buffer if allocated
+.IP \(bu
+Frees the server hostname buffer if allocated
+.IP \(bu
+Calls
+.BR curl_easy_cleanup (3)
+on the libcurl handle
+.IP \(bu
+Calls
+.BR curl_global_cleanup (3)
+.IP \(bu
+Sets the curl pointer to NULL
+.SS Safe Usage
+It is safe to call
+.BR copy_offload_cleanup ()
+on:
+.IP \(bu 3
+A handle that was successfully initialized
+.IP \(bu
+A handle that was partially configured (cleanup is idempotent)
+.PP
+It is NOT safe to call
+.BR copy_offload_cleanup ()
+on:
+.IP \(bu 3
+NULL pointers (causes segmentation fault)
+.IP \(bu
+Already cleaned-up handles
+.IP \(bu
+Handles that are actively being used by other threads
+.SH RETURN VALUE
+This function does not return a value.
+.SH ERRORS
+This function does not report errors or set
+.IR errno .
+If the handle is invalid or NULL, the behavior is undefined.
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_cleanup ()
+T}	Thread safety: MT-Unsafe
+.TE
+.PP
+This function is not thread-safe. It must not be called concurrently with any
+other operations on the same handle, including other calls to
+.BR copy_offload_cleanup ().
+.PP
+.BR curl_global_cleanup (3)
+affects process-wide state and should only be called when no other threads are
+using libcurl.
+.SH EXAMPLE
+.nf
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+
+    handle = copy_offload_init();
+    if (!handle) {
+        return 1;
+    }
+
+    /* Use the handle for operations... */
+
+    /* Always cleanup before exit */
+    copy_offload_cleanup(handle);
+
+    /* handle is now invalid, do not use */
+
+    return 0;
+}
+.fi
+.PP
+Example with error handling:
+.PP
+.nf
+#include <stdio.h>
+#include <copy-offload.h>
+
+int perform_copy(const char *src, const char *dst) {
+    COPY_OFFLOAD *handle = NULL;
+    char *job_name = NULL;
+    int ret = 1;
+
+    handle = copy_offload_init();
+    if (!handle) {
+        fprintf(stderr, "Init failed\\n");
+        goto cleanup;
+    }
+
+    if (copy_offload_configure(handle) != 0) {
+        fprintf(stderr, "Configure failed: %s\\n",
+                handle->err_message);
+        goto cleanup;
+    }
+
+    if (copy_offload_copy(handle, NULL, 4, 8, 0,
+                          (char *)src, (char *)dst,
+                          &job_name) != 0) {
+        fprintf(stderr, "Copy failed: %s\\n",
+                handle->err_message);
+        goto cleanup;
+    }
+
+    printf("Job: %s\\n", job_name);
+    ret = 0;
+
+cleanup:
+    free(job_name);
+    if (handle) {
+        copy_offload_cleanup(handle);
+    }
+    return ret;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+Every handle created with
+.BR copy_offload_init (3)
+must be freed with
+.BR copy_offload_cleanup ()
+to prevent memory leaks
+.IP \(bu
+Always call cleanup before program exit, even on error paths
+.IP \(bu
+Do not access handle members or use the handle after cleanup
+.IP \(bu
+Free any output strings (from
+.BR copy_offload_copy (),
+.BR copy_offload_list (),
+etc.) before calling cleanup
+.IP \(bu
+Use goto-style error handling to ensure cleanup is always performed
+.SH SEE ALSO
+.BR copy_offload_init (3),
+.BR curl_easy_cleanup (3),
+.BR curl_global_cleanup (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_configure.3
+++ b/man/man3/copy_offload_configure.3
@@ -1,0 +1,180 @@
+.TH COPY_OFFLOAD_CONFIGURE 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_configure \- configure handle for secure server communication
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_configure(COPY_OFFLOAD *" offload );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_configure ()
+function configures a COPY_OFFLOAD handle with all parameters necessary to
+establish secure TLS 1.3 communication with a copy-offload server.
+.PP
+This function performs the following configuration:
+.IP \(bu 3
+Enables TLS 1.3 with certificate verification
+.IP \(bu
+Sets HTTP/2 over TLS as the protocol
+.IP \(bu
+Configures API version header ("Accepts-version: 1.0")
+.IP \(bu
+Determines server hostname and port from environment
+.IP \(bu
+Retrieves local compute node hostname
+.IP \(bu
+Prepares for bearer token authentication
+.SS Server Discovery
+The function locates the copy-offload server using the following logic:
+.IP 1. 4
+If
+.B NNF_CONTAINER_LAUNCHER
+environment variable is set, uses its value as the server hostname (typical for
+MPI-launched servers)
+.IP 2.
+Otherwise, reads the hostname from
+.I /etc/local-rabbit.conf
+(typical for single-node configurations)
+.PP
+The server port is obtained from
+.B NNF_CONTAINER_PORTS
+environment variable. If multiple ports are specified (comma-separated), only
+the first port is used.
+.SS Authentication
+Bearer token authentication is configured but not loaded until the first request.
+The token is read from the
+.B DW_WORKFLOW_TOKEN
+environment variable when needed. If this variable is not set, requests will be
+made without authentication (may fail depending on server configuration).
+.SS TLS Configuration
+The function configures libcurl for secure communication:
+.IP \(bu 3
+Protocol: HTTPS (TLS 1.3)
+.IP \(bu
+Certificate verification: Enabled (peer and host)
+.IP \(bu
+Default certificate path: /etc/nnf-dm-usercontainer/cert.pem
+.IP \(bu
+HTTP version: HTTP/2 over TLS
+.PP
+The certificate path can be overridden before the first request using
+.BR copy_offload_override_cert (3).
+.SH RETURN VALUE
+Returns 0 on success.
+.PP
+Returns 1 on failure and sets
+.I offload->err_message
+to a descriptive error string. Possible failures include:
+.IP \(bu 3
+Unable to determine local hostname
+.IP \(bu
+.B NNF_CONTAINER_LAUNCHER
+not set and
+.I /etc/local-rabbit.conf
+not readable
+.IP \(bu
+.B NNF_CONTAINER_PORTS
+environment variable not set
+.IP \(bu
+Server hostname parsing errors
+.SH ERRORS
+This function does not set
+.I errno
+directly. Error information is stored in the handle's
+.I err_message
+field (null-terminated string up to CURL_ERROR_SIZE * 2 bytes).
+.PP
+Common error scenarios:
+.IP \(bu 3
+"Unable to get hostname: errno N" -
+.BR gethostname (2)
+failed
+.IP \(bu
+"Unable to get server host from environment variable..." - missing required
+environment variables or configuration files
+.IP \(bu
+"Unable to get server port from environment variable..." -
+.B NNF_CONTAINER_PORTS
+not set
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_configure ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+This function is thread-safe provided each thread uses its own COPY_OFFLOAD handle.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    int ret;
+
+    handle = copy_offload_init();
+    if (!handle) {
+        fprintf(stderr, "Initialization failed\\n");
+        return 1;
+    }
+
+    ret = copy_offload_configure(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Configuration failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    printf("Successfully configured for TLS communication\\n");
+
+    /* Now ready to submit requests... */
+
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+This function must be called after
+.BR copy_offload_init (3)
+and before any operations that communicate with the server
+.IP \(bu
+For testing without TLS, use
+.BR copy_offload_configure_without_tls (3)
+.IP \(bu
+Certificate and token can be overridden using
+.BR copy_offload_override_cert (3)
+and
+.BR copy_offload_override_token (3),
+but these must be called before the first request is sent
+.SH ENVIRONMENT
+.TP
+.B NNF_CONTAINER_LAUNCHER
+Hostname of the Rabbit node running the copy-offload server. Takes precedence
+over
+.IR /etc/local-rabbit.conf .
+.TP
+.B NNF_CONTAINER_PORTS
+Comma-separated list of server ports. The first port is used.
+.TP
+.B DW_WORKFLOW_TOKEN
+Bearer token for authentication. Loaded lazily on first request.
+.SH SEE ALSO
+.BR copy_offload_init (3),
+.BR copy_offload_configure_without_tls (3),
+.BR copy_offload_override_cert (3),
+.BR copy_offload_override_token (3),
+.BR copy_offload_override_hostname (3),
+.BR curl_easy_setopt (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_copy.3
+++ b/man/man3/copy_offload_copy.3
@@ -1,0 +1,199 @@
+.TH COPY_OFFLOAD_COPY 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_copy \- submit a new data movement request
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_copy(COPY_OFFLOAD *" offload ", const char *" profile_name ,
+.BI "                      int " slots ", int " max_slots ", int " dry_run ,
+.BI "                      char *" source_path ", char *" dest_path ,
+.BI "                      char **" output );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_copy ()
+function submits an asynchronous data movement request to the copy-offload server.
+The request is queued as a job and returns immediately with a job identifier that
+can be used to monitor progress, check status, or cancel the operation.
+.PP
+The function constructs a JSON request body conforming to API version 1.0 and
+sends it via HTTP POST to the server's /trial endpoint.
+.SS Parameters
+.TP
+.I offload
+Handle initialized with
+.BR copy_offload_init (3)
+and configured with
+.BR copy_offload_configure (3).
+.TP
+.I profile_name
+Name of the Data Movement profile to use. This profile is defined on the server
+and controls data movement tool selection, options, and behavior. Pass NULL or
+empty string to use the default profile.
+.TP
+.I slots
+Initial number of parallel data movement processes to use. Must be greater than
+0 and less than or equal to
+.IR max_slots .
+.TP
+.I max_slots
+Maximum number of parallel processes allowed. The server may scale up to this
+limit based on workload and available resources.
+.TP
+.I dry_run
+If non-zero, performs a dry-run operation that validates the request without
+actually moving data. Useful for testing paths and permissions. Pass 0 for actual
+data movement.
+.TP
+.I source_path
+Absolute path to the source file or directory. Must be accessible from the Rabbit
+node running the copy-offload server.
+.TP
+.I dest_path
+Absolute path to the destination location. Parent directory must exist and be
+writable.
+.TP
+.I output
+Pointer to a char* that will receive the job name string. The caller is responsible
+for calling
+.BR free (3)
+on this string if it is non-NULL. The job name format is typically "job-NNNNNNNN"
+where NNNNNNNN is a zero-padded sequence number.
+.SS Request Format
+The function sends a JSON request with the following structure:
+.PP
+.nf
+{
+  "computeName": "<local-hostname>",
+  "sourcePath": "<source_path>",
+  "destinationPath": "<dest_path>",
+  "dmProfile": "<profile_name>",
+  "dryrun": true|false,
+  "dcpOptions": "",
+  "logStdout": true,
+  "storeStdout": false,
+  "slots": <slots>,
+  "maxSlots": <max_slots>
+}
+.fi
+.SH RETURN VALUE
+Returns 0 on success. On success,
+.I *output
+contains the job name string that must be freed by the caller.
+.PP
+Returns 1 on failure. On failure,
+.I offload->err_message
+contains a descriptive error message. The
+.I offload->http_code
+field contains the HTTP response code if the request reached the server, or \-1
+if there was a libcurl error before receiving an HTTP response.
+.PP
+Common HTTP response codes:
+.IP \(bu 3
+200 - Success, job submitted
+.IP \(bu
+400 - Bad request (invalid parameters)
+.IP \(bu
+401 - Unauthorized (invalid or missing bearer token)
+.IP \(bu
+500 - Server error
+.SH ERRORS
+Error messages are stored in
+.IR offload->err_message .
+Common errors include:
+.IP \(bu 3
+"Error formatting request: buffer too small" - Request parameters too long for
+internal buffers
+.IP \(bu
+"Error formatting body: buffer too small" - JSON body exceeds buffer
+.IP \(bu
+libcurl errors - Connection failures, DNS errors, TLS errors
+.IP \(bu
+Server HTTP errors - Returned in response body and copied to err_message
+.PP
+This function does not set
+.IR errno .
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_copy ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+Thread-safe if each thread uses its own COPY_OFFLOAD handle.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_name = NULL;
+    int ret;
+
+    handle = copy_offload_init();
+    if (!handle) return 1;
+
+    ret = copy_offload_configure(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Configure error: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    /* Submit copy with 4 initial slots, up to 8 max */
+    ret = copy_offload_copy(handle, "high-performance",
+                            4, 8, 0,
+                            "/lustre/data/input.dat",
+                            "/nvme/scratch/output.dat",
+                            &job_name);
+    if (ret != 0) {
+        fprintf(stderr, "Copy failed: %s (HTTP %ld)\\n",
+                handle->err_message, handle->http_code);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    printf("Copy job submitted successfully: %s\\n", job_name);
+
+    /* Monitor or wait for completion... */
+
+    free(job_name);
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+The job name returned in
+.I *output
+must be freed by the caller
+.IP \(bu
+Data movement proceeds asynchronously after this function returns
+.IP \(bu
+Use
+.BR copy_offload_status (3)
+to monitor job progress
+.IP \(bu
+Source and destination paths must be absolute paths
+.IP \(bu
+Profile names are server-defined and may vary by installation
+.IP \(bu
+The server may apply quota limits on slots and job count
+.SH SEE ALSO
+.BR copy_offload_status (3),
+.BR copy_offload_list (3),
+.BR copy_offload_cancel (3),
+.BR copy_offload_init (3),
+.BR copy_offload_configure (3),
+.BR free (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_init.3
+++ b/man/man3/copy_offload_init.3
@@ -1,0 +1,118 @@
+.TH COPY_OFFLOAD_INIT 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_init \- create and initialize a copy-offload handle
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "COPY_OFFLOAD *copy_offload_init(void);"
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_init ()
+function creates and initializes a new COPY_OFFLOAD handle for communicating
+with a copy-offload server. This handle must be used for all subsequent
+copy-offload operations.
+.PP
+The function performs the following initialization:
+.IP \(bu 3
+Calls
+.BR curl_global_init (3)
+with CURL_GLOBAL_ALL
+.IP \(bu
+Creates a new CURL easy handle via
+.BR curl_easy_init (3)
+.IP \(bu
+Allocates and zeros a COPY_OFFLOAD structure
+.IP \(bu
+Sets initial state for error tracking
+.PP
+The returned handle is not yet configured for communication. After initialization,
+the caller must invoke
+.BR copy_offload_configure (3)
+or
+.BR copy_offload_configure_without_tls (3)
+to establish connection parameters before performing any operations that
+communicate with the server.
+.PP
+The handle maintains internal state including:
+.IP \(bu 3
+libcurl session information
+.IP \(bu
+Server connection parameters
+.IP \(bu
+TLS certificate and authentication token
+.IP \(bu
+Error messages and HTTP status codes
+.IP \(bu
+Protocol and hostname information
+.SH RETURN VALUE
+On success, returns a pointer to a newly allocated COPY_OFFLOAD handle.
+.PP
+On failure, prints an error message to stderr and returns NULL. Failure typically
+indicates that libcurl initialization failed, which may occur if the system is
+out of memory or libcurl cannot be initialized.
+.SH ERRORS
+This function does not set
+.IR errno .
+Error conditions are reported by returning NULL and printing diagnostic information
+to stderr.
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_init ()
+T}	Thread safety: MT-Unsafe
+.TE
+.PP
+This function calls
+.BR curl_global_init (3)
+which is not thread-safe. It should only be called once per process, typically
+from the main thread before any threads are created.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+
+    handle = copy_offload_init();
+    if (!handle) {
+        fprintf(stderr, "Failed to initialize handle\\n");
+        return 1;
+    }
+
+    /* Configure and use the handle... */
+
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+Every handle created with
+.BR copy_offload_init ()
+must be freed with
+.BR copy_offload_cleanup (3)
+to prevent memory leaks
+.IP \(bu
+The handle is not ready for use until
+.BR copy_offload_configure (3)
+or
+.BR copy_offload_configure_without_tls (3)
+has been called
+.IP \(bu
+Calling this function multiple times creates independent handles
+.SH SEE ALSO
+.BR copy_offload_configure (3),
+.BR copy_offload_configure_without_tls (3),
+.BR copy_offload_cleanup (3),
+.BR curl_easy_init (3),
+.BR curl_global_init (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_list.3
+++ b/man/man3/copy_offload_list.3
@@ -1,0 +1,159 @@
+.TH COPY_OFFLOAD_LIST 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_list \- list active copy-offload jobs
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_list(COPY_OFFLOAD *" offload ", char **" output );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_list ()
+function retrieves a list of all active copy-offload jobs on the server. This
+includes jobs that are queued, starting, running, or recently completed but not
+yet expired from the server's job cache.
+.PP
+The function sends an HTTP GET request to the server's /list endpoint and returns
+a comma-separated list of job names.
+.SS Parameters
+.TP
+.I offload
+Handle initialized and configured for server communication.
+.TP
+.I output
+Pointer to a char* that will receive the comma-separated list of job names. The
+caller is responsible for calling
+.BR free (3)
+on this string if it is non-NULL. If there are no active jobs,
+.I *output
+will be an empty string (not NULL).
+.SS Output Format
+The output string contains job names separated by commas with no spaces:
+.PP
+.in +4n
+.EX
+job-00000001,job-00000003,job-00000007
+.EE
+.in
+.PP
+If there are no active jobs, the output is an empty string.
+.PP
+Job names are in the format returned by
+.BR copy_offload_copy (3),
+typically "job-NNNNNNNN" where NNNNNNNN is a zero-padded sequence number.
+.SH RETURN VALUE
+Returns 0 on success. On success,
+.I *output
+contains the job list string that must be freed by the caller with
+.BR free (3).
+.PP
+Returns 1 on failure. On failure,
+.I offload->err_message
+contains a descriptive error message. The
+.I offload->http_code
+field contains the HTTP response code if available.
+.PP
+Common HTTP response codes:
+.IP \(bu 3
+200 - Success
+.IP \(bu
+401 - Unauthorized (invalid or missing bearer token)
+.IP \(bu
+500 - Server error
+.SH ERRORS
+Error messages are stored in
+.IR offload->err_message .
+Common errors include:
+.IP \(bu 3
+"Error formatting request: buffer too small" - URL construction failed
+.IP \(bu
+libcurl errors - Connection failures, DNS resolution errors
+.IP \(bu
+Server HTTP errors - Authentication failures, server unavailable
+.PP
+This function does not set
+.IR errno .
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_list ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+Thread-safe if each thread uses its own COPY_OFFLOAD handle.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_list = NULL;
+    char *job, *saveptr;
+    int ret;
+
+    handle = copy_offload_init();
+    if (!handle) return 1;
+
+    ret = copy_offload_configure(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Configure failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    ret = copy_offload_list(handle, &job_list);
+    if (ret != 0) {
+        fprintf(stderr, "List failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    if (job_list && strlen(job_list) > 0) {
+        printf("Active jobs:\\n");
+        job = strtok_r(job_list, ",", &saveptr);
+        while (job != NULL) {
+            printf("  %s\\n", job);
+            job = strtok_r(NULL, ",", &saveptr);
+        }
+    } else {
+        printf("No active jobs\\n");
+    }
+
+    free(job_list);
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+The output string must be freed by the caller using
+.BR free (3)
+.IP \(bu
+Job list reflects the server's current state at the time of the query
+.IP \(bu
+Completed jobs remain in the list until expired from the server cache
+.IP \(bu
+Jobs may complete or be cancelled between listing and subsequent operations
+.IP \(bu
+Parse the comma-separated list using
+.BR strtok (3)
+or similar functions
+.SH SEE ALSO
+.BR copy_offload_copy (3),
+.BR copy_offload_status (3),
+.BR copy_offload_cancel (3),
+.BR strtok (3),
+.BR free (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_shutdown.3
+++ b/man/man3/copy_offload_shutdown.3
@@ -1,0 +1,160 @@
+.TH COPY_OFFLOAD_SHUTDOWN 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_shutdown \- shutdown the copy-offload server
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_shutdown(COPY_OFFLOAD *" offload );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_shutdown ()
+function requests a graceful shutdown of the copy-offload server. This operation
+is typically used during system maintenance or when terminating a workflow that
+launched its own copy-offload server instance.
+.PP
+The function performs a two-step process:
+.IP 1. 4
+Queries the server for active jobs using
+.BR copy_offload_list (3)
+.IP 2.
+If no active jobs exist, sends a shutdown request to the server
+.PP
+The server will exit cleanly after completing the shutdown request, terminating
+its process and freeing all resources.
+.SS Safety Checks
+The function refuses to shutdown the server if any jobs are active (queued,
+starting, or running). This prevents data loss or corruption from interrupted
+transfers. To forcefully shutdown, all active jobs must first be cancelled using
+.BR copy_offload_cancel (3)
+or allowed to complete.
+.SS Shutdown Request
+If the safety check passes, the function sends an HTTP POST request to the server's
+/shutdown endpoint. The server will:
+.IP \(bu 3
+Complete any final cleanup operations
+.IP \(bu
+Close all network connections
+.IP \(bu
+Exit with status code 0
+.SH RETURN VALUE
+Returns 0 on success, indicating the server has acknowledged the shutdown request
+and is terminating.
+.PP
+Returns 1 on failure. Failure reasons are placed in
+.IR offload->err_message .
+Common failures include:
+.IP \(bu 3
+Active jobs still running - Error message indicates that cancellation or completion
+is required before shutdown
+.IP \(bu
+Communication failure - Unable to reach the server
+.IP \(bu
+Authentication failure - Invalid bearer token
+.IP \(bu
+Permission denied - Server policy prohibits shutdown requests
+.PP
+The
+.I offload->http_code
+field contains the HTTP status code if the request reached the server.
+.SH ERRORS
+Error messages are stored in
+.IR offload->err_message :
+.IP \(bu 3
+"Cannot shutdown: active copy-offload requests are still running." - One or more
+jobs are active; use
+.BR copy_offload_list (3)
+to identify them
+.IP \(bu
+"Error formatting shutdown request" - Internal buffer overflow
+.IP \(bu
+"Failed to shutdown server (HTTP %ld)" - Server refused the shutdown
+.IP \(bu
+libcurl errors - Network failures, timeouts
+.PP
+This function does not set
+.IR errno .
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_shutdown ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+Thread-safe if each thread uses its own COPY_OFFLOAD handle. However, shutting
+down the server affects all clients globally.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_list = NULL;
+    int ret;
+
+    handle = copy_offload_init();
+    if (!handle) return 1;
+
+    ret = copy_offload_configure(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Configure failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    /* Check for active jobs before shutdown */
+    ret = copy_offload_list(handle, &job_list);
+    if (ret == 0 && job_list && strlen(job_list) > 0) {
+        printf("Active jobs exist: %s\\n", job_list);
+        printf("Cannot shutdown. Cancel jobs first.\\n");
+        free(job_list);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+    free(job_list);
+
+    /* No active jobs, safe to shutdown */
+    ret = copy_offload_shutdown(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Shutdown failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    printf("Server shutdown initiated successfully\\n");
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+This function is intended for administrative or workflow cleanup tasks
+.IP \(bu
+Shutting down the server affects all users sharing that server instance
+.IP \(bu
+The server must be restarted manually if shutdown was unintentional
+.IP \(bu
+In multi-user environments, consider policy restrictions on shutdown
+.IP \(bu
+The function queries for active jobs internally; no need to call
+.BR copy_offload_list ()
+separately unless displaying job information
+.IP \(bu
+After successful shutdown, subsequent operations on any handle will fail with
+connection errors
+.SH SEE ALSO
+.BR copy_offload_list (3),
+.BR copy_offload_cancel (3),
+.BR copy_offload_init (3),
+.BR libcopyoffload (3)

--- a/man/man3/copy_offload_status.3
+++ b/man/man3/copy_offload_status.3
@@ -1,0 +1,212 @@
+.TH COPY_OFFLOAD_STATUS 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+copy_offload_status \- query the status of a data movement job
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.PP
+.BI "int copy_offload_status(COPY_OFFLOAD *" offload ", char *" job_name ,
+.BI "                        int " max_wait_secs ,
+.BI "                        copy_offload_status_response_t **" status_response );
+.PP
+.BI "void copy_offload_status_cleanup("
+.BI "                        copy_offload_status_response_t *" status_response );
+.PP
+.BI "void copy_offload_status_pretty_print(FILE *" out ,
+.BI "                        copy_offload_status_response_t *" status_response );
+.fi
+.SH DESCRIPTION
+The
+.BR copy_offload_status ()
+function queries the copy-offload server for the current status of a data movement
+job previously submitted via
+.BR copy_offload_copy (3).
+The function can either return immediately with the current status or wait for
+the job to complete.
+.PP
+The response is parsed from JSON into a structured format that includes job state,
+progress information, timing data, and error messages if any.
+.SS Parameters
+.TP
+.I offload
+Handle initialized and configured for server communication.
+.TP
+.I job_name
+Job identifier returned by
+.BR copy_offload_copy (3).
+Typically in the format "job-NNNNNNNN".
+.TP
+.I max_wait_secs
+Maximum time in seconds to wait for the job to complete:
+.RS
+.IP \(bu 3
+0 - Return immediately with current status
+.IP \(bu
+\-1 - Wait indefinitely until completion
+.IP \(bu
+>0 - Wait up to specified seconds, return earlier if completed
+.RE
+.TP
+.I status_response
+Pointer to a pointer that will receive the status response structure. The caller
+must call
+.BR copy_offload_status_cleanup (3)
+on this structure to free associated memory.
+.SS Status Response Structure
+The
+.B copy_offload_status_response_t
+structure contains:
+.TP
+.I state
+Current job state (e.g., "Starting", "Running", "Completed", "Error").
+.TP
+.I status
+More detailed status description.
+.TP
+.I message
+Additional information about the current state or any errors.
+.TP
+.I command_status
+Structure containing:
+.RS
+.IP \(bu 3
+.I command
+- The data movement command being executed
+.IP \(bu
+.I progress
+- Percentage complete (0-100)
+.IP \(bu
+.I elapsed_time
+- Duration of operation (e.g., "1m30s")
+.IP \(bu
+.I last_message
+- Most recent output line from the command
+.IP \(bu
+.I last_message_time
+- Timestamp of last_message
+.RE
+.TP
+.I start_time
+Local time when the job started.
+.TP
+.I end_time
+Local time when the job completed (NULL if still running).
+.SS Helper Functions
+.TP
+.BR copy_offload_status_cleanup ()
+Frees all memory associated with a status response structure, including the
+underlying JSON object. After calling this function, no fields of the structure
+should be accessed.
+.TP
+.BR copy_offload_status_pretty_print ()
+Writes a human-readable representation of the status response to the specified
+file stream. Useful for debugging and logging.
+.SH RETURN VALUE
+.BR copy_offload_status ()
+returns 0 on success. On success,
+.I *status_response
+points to a valid structure that must be freed with
+.BR copy_offload_status_cleanup (3).
+.PP
+Returns 1 on failure. On failure,
+.I offload->err_message
+contains an error description and
+.I *status_response
+may be NULL or point to a partial response structure.
+.PP
+.BR copy_offload_status_cleanup ()
+and
+.BR copy_offload_status_pretty_print ()
+do not return values.
+.SH ERRORS
+Error messages are stored in
+.IR offload->err_message .
+Common errors:
+.IP \(bu 3
+"Error formatting request: buffer too small" - Job name or parameters too long
+.IP \(bu
+libcurl errors - Network failures, connection timeouts
+.IP \(bu
+HTTP 404 - Job not found (invalid job_name or job expired)
+.IP \(bu
+HTTP 401 - Authentication failure
+.PP
+This function does not set
+.IR errno .
+.SH ATTRIBUTES
+.TS
+allbox;
+lb lb
+l l.
+Interface	Attribute
+T{
+.BR copy_offload_status ()
+T}	Thread safety: MT-Safe
+.TE
+.PP
+Thread-safe if each thread uses its own COPY_OFFLOAD handle and status_response
+structure.
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_name = NULL;
+    copy_offload_status_response_t *status = NULL;
+    int ret;
+
+    handle = copy_offload_init();
+    copy_offload_configure(handle);
+
+    /* Submit a job */
+    ret = copy_offload_copy(handle, NULL, 4, 8, 0,
+                            "/source/data", "/dest/data",
+                            &job_name);
+    if (ret != 0) {
+        /* handle error */
+        return 1;
+    }
+
+    /* Wait up to 5 minutes for completion */
+    ret = copy_offload_status(handle, job_name, 300, &status);
+    if (ret != 0) {
+        fprintf(stderr, "Status query failed: %s\\n",
+                handle->err_message);
+    } else if (status) {
+        printf("Job state: %s\\n", status->state);
+        printf("Progress: %d%%\\n", status->command_status.progress);
+
+        /* Pretty-print full status */
+        copy_offload_status_pretty_print(stdout, status);
+
+        copy_offload_status_cleanup(status);
+    }
+
+    free(job_name);
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH NOTES
+.IP \(bu 3
+The status_response structure contains pointers into the internal JSON object.
+These pointers become invalid after
+.BR copy_offload_status_cleanup ()
+.IP \(bu
+When max_wait_secs is 0, the function returns immediately, making it suitable
+for polling loops
+.IP \(bu
+The server may enforce maximum wait times regardless of max_wait_secs
+.IP \(bu
+Progress information is only available when using dcp-based data movement tools
+.SH SEE ALSO
+.BR copy_offload_copy (3),
+.BR copy_offload_cancel (3),
+.BR copy_offload_list (3),
+.BR json_tokener_parse (3),
+.BR libcopyoffload (3)

--- a/man/man3/libcopyoffload.3
+++ b/man/man3/libcopyoffload.3
@@ -1,0 +1,190 @@
+.TH LIBCOPYOFFLOAD 3 "January 2025" "libcopyoffload" "Library Functions Manual"
+.SH NAME
+libcopyoffload \- library for offloading data movement operations
+.SH LIBRARY
+Copy Offload Library (libcopyoffload, \-lcopyoffload)
+.br
+Also requires: libcurl (\-lcurl), libjson-c (\-ljson-c)
+.SH SYNOPSIS
+.nf
+.B #include <copy-offload.h>
+.sp
+Link with \fI\-lcopyoffload \-lcurl \-ljson-c\fP
+.fi
+.SH DESCRIPTION
+The
+.B libcopyoffload
+library provides a C API for offloading data movement operations to a remote
+copy-offload server. This allows compute applications to initiate, monitor, and
+manage large-scale data transfers without blocking application execution.
+.PP
+The library establishes secure TLS connections to copy-offload servers running
+on NearNodeFlash (NNF) Rabbit nodes and supports authentication via bearer tokens.
+Data movement requests are submitted as asynchronous jobs that can be monitored,
+listed, and cancelled.
+.SS Key Features
+.IP \(bu 3
+Secure TLS 1.3 communication with copy-offload servers
+.IP \(bu
+Bearer token authentication for workflow isolation
+.IP \(bu
+Asynchronous data movement job submission
+.IP \(bu
+Job monitoring with progress tracking
+.IP \(bu
+Job cancellation capability
+.IP \(bu
+Support for dry-run operations
+.IP \(bu
+Configurable parallelism (slots)
+.SS Typical Workflow
+.IP 1. 4
+Initialize handle with
+.BR copy_offload_init (3)
+.IP 2.
+Configure connection with
+.BR copy_offload_configure (3)
+.IP 3.
+Submit copy request with
+.BR copy_offload_copy (3)
+.IP 4.
+Monitor progress with
+.BR copy_offload_status (3)
+.IP 5.
+Clean up with
+.BR copy_offload_cleanup (3)
+.SS Environment Variables
+.TP
+.B DW_WORKFLOW_TOKEN
+Bearer token for authenticating with the copy-offload server. This token is
+typically provided by the workflow management system and grants access to the
+user's workflow namespace.
+.TP
+.B NNF_CONTAINER_LAUNCHER
+The hostname of the Rabbit node running the copy-offload server when using MPI.
+If not set, the library reads from
+.IR /etc/local-rabbit.conf .
+.TP
+.B NNF_CONTAINER_PORTS
+Comma-separated list of ports the copy-offload server is listening on. The
+library uses the first port in the list.
+.SS Files
+.TP
+.I /etc/local-rabbit.conf
+Contains the hostname of the local Rabbit node. Used when
+.B NNF_CONTAINER_LAUNCHER
+is not set.
+.TP
+.I /etc/nnf-dm-usercontainer/cert.pem
+Default TLS certificate file in PEM format. Used to verify the server's identity
+during TLS handshake.
+.SS API Version
+The library uses API version 1.0. The version is communicated to the server via
+the "Accepts-version: 1.0" HTTP header. Version mismatches will result in
+connection errors.
+.SS Error Handling
+Most functions return 0 on success and 1 on failure. On failure, a detailed error
+message is available in the handle's
+.I err_message
+field. The
+.I err_message
+buffer is CURL_ERROR_SIZE * 2 bytes and contains either libcurl error codes and
+messages or HTTP response errors from the server.
+.PP
+HTTP response codes are available in the handle's
+.I http_code
+field after operations that communicate with the server. A value of \-1 indicates
+no HTTP response was received (typically due to libcurl errors).
+.SS Thread Safety
+The
+.B libcopyoffload
+library is not thread-safe. Each thread should use its own COPY_OFFLOAD handle.
+The underlying libcurl library is initialized with
+.BR curl_global_init (3)
+which must only be called once per process.
+.SS Memory Management
+.IP \(bu 3
+Handles created with
+.BR copy_offload_init (3)
+must be freed with
+.BR copy_offload_cleanup (3)
+.IP \(bu
+String outputs returned via char** parameters must be freed by the caller using
+.BR free (3)
+.IP \(bu
+Status response structures must be cleaned up with
+.BR copy_offload_status_cleanup (3)
+.SH EXAMPLE
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <copy-offload.h>
+
+int main(void) {
+    COPY_OFFLOAD *handle;
+    char *job_name = NULL;
+    int ret;
+
+    /* Initialize and configure */
+    handle = copy_offload_init();
+    if (!handle) {
+        fprintf(stderr, "Failed to initialize\\n");
+        return 1;
+    }
+
+    ret = copy_offload_configure(handle);
+    if (ret != 0) {
+        fprintf(stderr, "Configure failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    /* Submit copy request */
+    ret = copy_offload_copy(handle, "default", 4, 8, 0,
+                            "/source/data", "/dest/data",
+                            &job_name);
+    if (ret != 0) {
+        fprintf(stderr, "Copy failed: %s\\n",
+                handle->err_message);
+        copy_offload_cleanup(handle);
+        return 1;
+    }
+
+    printf("Job submitted: %s\\n", job_name);
+
+    /* Monitor status */
+    copy_offload_status_response_t *status = NULL;
+    ret = copy_offload_status(handle, job_name, 300, &status);
+    if (ret == 0 && status) {
+        copy_offload_status_pretty_print(stdout, status);
+        copy_offload_status_cleanup(status);
+    }
+
+    free(job_name);
+    copy_offload_cleanup(handle);
+    return 0;
+}
+.fi
+.SH SEE ALSO
+.BR copy_offload_init (3),
+.BR copy_offload_configure (3),
+.BR copy_offload_copy (3),
+.BR copy_offload_status (3),
+.BR copy_offload_list (3),
+.BR copy_offload_cancel (3),
+.BR copy_offload_cleanup (3),
+.BR curl_easy_init (3),
+.BR json_tokener_parse (3)
+.PP
+NearNodeFlash Copy-Offload Documentation:
+.br
+https://nearnodeflash.github.io/dev/guides/data-movement/copy-offload/
+.SH NOTES
+This library is designed for use within the NearNodeFlash (NNF) environment on
+HPE systems. It requires a properly configured copy-offload server and workflow
+infrastructure.
+.SH COPYRIGHT
+Copyright 2024-2025 Hewlett Packard Enterprise Development LP
+.PP
+Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
Document the core library functions required for a developer to write an application which uses the libcopyoffload library.

These pages were generated by Claude using the daemons/lib-copy-offload/*.[ch] files as a reference.  They need to be reviewed for correctness by someone more familiar with the library.  This PR also still needs a Makefile which installs the man pages.

