### PR TITLE
Fix libcopyoffload bugs found during man page review

### DIFF
--- a/daemons/copy-offload-testing/e2e-mocked.sh
+++ b/daemons/copy-offload-testing/e2e-mocked.sh
@@ -184,6 +184,15 @@ if [[ $output != "" ]]; then
     exit 1
 fi
 
+# Sticky-method regression test: exercises multiple operations on a single
+# handle to verify that HTTP methods are not corrupted across calls.
+# shellcheck disable=SC2086
+if ! $CO $CO_TLS_ARGS -R -S /mnt/nnf/ooo -D /lus/foo; then
+    echo "FAIL: sticky-method regression test failed"
+    kill "$srvr_pid"
+    exit 1
+fi
+
 if [[ -z $SKIP_TLS ]]; then
     SAY_CURL="Verify that TLS args are required for curl. Expect curl to fail here."
     SAY_CURL_ERR="FAIL: Expected curl to get failure when not specifying the TLS cert/key"

--- a/daemons/lib-copy-offload/copy-offload-status.c
+++ b/daemons/lib-copy-offload/copy-offload-status.c
@@ -121,8 +121,12 @@ void copy_offload_status_pretty_print(FILE *out, copy_offload_status_response_t 
  * the @response object.
  */
 void copy_offload_status_cleanup(copy_offload_status_response_t *response) {
-    if (response != NULL && response->_root != NULL) {
-        json_object_put(response->_root);
-        response->_root = NULL;
+    if (response != NULL) {
+        if (response->_root != NULL) {
+            json_object_put(response->_root);
+            response->_root = NULL;
+        }
+        // Free the struct itself, which was calloc'd by _copy_offload_status_parse().
+        free(response);
     }
 }

--- a/daemons/lib-copy-offload/copy-offload.c
+++ b/daemons/lib-copy-offload/copy-offload.c
@@ -146,7 +146,9 @@ static int _copy_offload_configure(COPY_OFFLOAD *offload, int skip_tls) {
         curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_3);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
         //curl_easy_setopt(curl, CURLOPT_SSL_VERIFYSTATUS, 1L);
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
+        // Use 2L for full hostname verification; 1L only checks that a
+        // name field exists without verifying it matches the hostname.
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
 
         curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
     }
@@ -324,6 +326,8 @@ int copy_offload_hello(COPY_OFFLOAD *offload, char **output) {
         return ret;
     }
     curl_easy_setopt(offload->curl, CURLOPT_URL, urlbuf);
+    // Reset to GET in case a prior call set CURLOPT_CUSTOMREQUEST.
+    curl_easy_setopt(offload->curl, CURLOPT_HTTPGET, 1L);
 
     http_code = copy_offload_perform(offload, &chunk);
     if (http_code == 200) {
@@ -368,6 +372,8 @@ int copy_offload_status(COPY_OFFLOAD *offload, char *job_name, int max_wait_secs
         return ret;
     }
     curl_easy_setopt(offload->curl, CURLOPT_URL, urlbuf);
+    // Reset to GET in case a prior call set CURLOPT_CUSTOMREQUEST.
+    curl_easy_setopt(offload->curl, CURLOPT_HTTPGET, 1L);
 
     http_code = copy_offload_perform(offload, &chunk);
     if (http_code == 200)
@@ -378,6 +384,9 @@ int copy_offload_status(COPY_OFFLOAD *offload, char *job_name, int max_wait_secs
         chop(&output);
         free(chunk.response);
         *status_response = _copy_offload_status_parse(output);
+        // The parser copies what it needs into the json object tree,
+        // so the input string can be freed now.
+        free(output);
     }
     return ret;
 }
@@ -401,6 +410,8 @@ int copy_offload_list(COPY_OFFLOAD *offload, char **output) {
         return ret;
     }
     curl_easy_setopt(offload->curl, CURLOPT_URL, urlbuf);
+    // Reset to GET in case a prior call set CURLOPT_CUSTOMREQUEST.
+    curl_easy_setopt(offload->curl, CURLOPT_HTTPGET, 1L);
 
     http_code = copy_offload_perform(offload, &chunk);
     if (http_code == 200)
@@ -433,6 +444,9 @@ int copy_offload_cancel(COPY_OFFLOAD *offload, char *job_name, char **output) {
     curl_easy_setopt(offload->curl, CURLOPT_CUSTOMREQUEST, "DELETE");
 
     http_code = copy_offload_perform(offload, &chunk);
+    // CURLOPT_CUSTOMREQUEST is sticky; reset it so subsequent calls
+    // (e.g. list, status) don't inherit the DELETE method.
+    curl_easy_setopt(offload->curl, CURLOPT_CUSTOMREQUEST, NULL);
     if (http_code == 200)
         ret = 0;
     if (chunk.response != NULL) {
@@ -557,6 +571,9 @@ int copy_offload_shutdown(COPY_OFFLOAD *offload) {
     chunk.response = NULL;
     chunk.size = 0;
     http_code = copy_offload_perform(offload, &chunk);
+    // CURLOPT_CUSTOMREQUEST is sticky; reset it so subsequent calls
+    // don't inherit the POST method.
+    curl_easy_setopt(offload->curl, CURLOPT_CUSTOMREQUEST, NULL);
     if (http_code == 200) {
         ret = 0;
     } else {

--- a/daemons/lib-copy-offload/test-tool/main.c
+++ b/daemons/lib-copy-offload/test-tool/main.c
@@ -58,12 +58,127 @@ void usage(const char **argv) {
     fprintf(stderr, "\n");
     fprintf(stderr, "Usage: %s [COMMON_ARGS] -X\n", argv[0]);
     fprintf(stderr, "    -X     Shutdown the copy-offload server.\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: %s [COMMON_ARGS] -R -S SOURCE_PATH -D DEST_PATH\n", argv[0]);
+    fprintf(stderr, "    -R            Run sticky-method regression test.\n");
+    fprintf(stderr, "                  Exercises multiple operations on a single handle to verify\n");
+    fprintf(stderr, "                  that HTTP methods are not corrupted by prior calls.\n");
     fprintf(stderr, "COMMON_ARGS\n");
     fprintf(stderr, "    -v                  Request verbose output from this tool.\n");
     fprintf(stderr, "    -V                  Request verbose output from libcurl.\n");
     fprintf(stderr, "    -s                  Skip TLS configuration.\n");
     fprintf(stderr, "    -t TOKEN_FILE       Bearer token file.\n");
     fprintf(stderr, "    -x CERT_FILE        CA/Server certificate file. A self-signed certificate.\n");
+}
+
+/*
+ * Sticky-method regression test.
+ * Exercises multiple operations on a single handle to verify that HTTP methods
+ * (GET, POST, DELETE) are not corrupted by CURLOPT_CUSTOMREQUEST stickiness.
+ *
+ * Sequence:
+ *   1. copy (POST)        → creates a job
+ *   2. cancel (DELETE)     → sets CURLOPT_CUSTOMREQUEST to "DELETE"
+ *   3. list (GET)          → would fail if DELETE leaked through
+ *   4. hello (GET)         → would fail if DELETE leaked through
+ *   5. copy (POST)         → creates another job
+ *   6. status (GET)        → would fail if POST leaked through
+ *   7. cancel (DELETE)     → cleanup
+ *
+ * Returns 0 on success, 1 on failure.
+ */
+static int test_sticky_methods(COPY_OFFLOAD *offload, char *source_path, char *dest_path) {
+    char *output = NULL;
+    char *job1 = NULL;
+    char *job2 = NULL;
+    copy_offload_status_response_t *status_response = NULL;
+    int ret;
+
+    /* Step 1: copy → POST */
+    fprintf(stderr, "sticky-test: copy #1\n");
+    ret = copy_offload_copy(offload, NULL, -1, -1, 0, source_path, dest_path, &job1);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: copy #1 failed: %s\n", offload->err_message);
+        return 1;
+    }
+    if (job1 == NULL) {
+        fprintf(stderr, "FAIL sticky-test: copy #1 returned NULL job name\n");
+        return 1;
+    }
+    fprintf(stderr, "sticky-test: copy #1 got job: %s\n", job1);
+
+    /* Step 2: cancel → DELETE (this is what makes CURLOPT_CUSTOMREQUEST sticky) */
+    fprintf(stderr, "sticky-test: cancel job %s\n", job1);
+    ret = copy_offload_cancel(offload, job1, &output);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: cancel failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (output != NULL) { free(output); output = NULL; }
+
+    /* Step 3: list → GET (would send DELETE if sticky bug is present) */
+    fprintf(stderr, "sticky-test: list after cancel\n");
+    ret = copy_offload_list(offload, &output);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: list after cancel failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (output != NULL) { free(output); output = NULL; }
+
+    /* Step 4: hello → GET (another GET to verify) */
+    fprintf(stderr, "sticky-test: hello after cancel\n");
+    ret = copy_offload_hello(offload, &output);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: hello after cancel failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (output != NULL) { free(output); output = NULL; }
+
+    /* Step 5: copy → POST (creates a second job) */
+    fprintf(stderr, "sticky-test: copy #2\n");
+    ret = copy_offload_copy(offload, NULL, -1, -1, 0, source_path, dest_path, &job2);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: copy #2 failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (job2 == NULL) {
+        fprintf(stderr, "FAIL sticky-test: copy #2 returned NULL job name\n");
+        goto fail;
+    }
+    fprintf(stderr, "sticky-test: copy #2 got job: %s\n", job2);
+
+    /* Step 6: status → GET (would fail if POST leaked through) */
+    fprintf(stderr, "sticky-test: status for job %s\n", job2);
+    ret = copy_offload_status(offload, job2, 0, &status_response);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: status failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (status_response != NULL) {
+        copy_offload_status_cleanup(status_response);
+        status_response = NULL;
+    }
+
+    /* Step 7: cancel → cleanup */
+    fprintf(stderr, "sticky-test: cancel job %s\n", job2);
+    ret = copy_offload_cancel(offload, job2, &output);
+    if (ret != 0) {
+        fprintf(stderr, "FAIL sticky-test: cancel #2 failed: %s\n", offload->err_message);
+        goto fail;
+    }
+    if (output != NULL) { free(output); output = NULL; }
+
+    fprintf(stderr, "sticky-test: PASS\n");
+    free(job1);
+    free(job2);
+    return 0;
+
+fail:
+    if (output != NULL) free(output);
+    if (job1 != NULL) free(job1);
+    if (job2 != NULL) free(job2);
+    if (status_response != NULL) copy_offload_status_cleanup(status_response);
+    return 1;
 }
 
 /*
@@ -93,11 +208,12 @@ int main(int argc, const char **argv) {
     int H_opt = 0;
     int q_opt = 0;
     int X_opt = 0;
+    int R_opt = 0;
     int max_wait_secs = 0;
     int ret;
     copy_offload_status_response_t *status_response = NULL;
 
-    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:P:S:D:m:M:dHqj:w:X")) != -1) {
+    while ((c = getopt(argc, cargv, "hvVlst:x:c:oC:P:S:D:m:M:dHqj:w:XR")) != -1) {
         switch (c) {
             case 'c':
                 c_opt = 1;
@@ -160,6 +276,9 @@ int main(int argc, const char **argv) {
             case 'X':
                 X_opt = 1;
                 break;
+            case 'R':
+                R_opt = 1;
+                break;
             default:
                 usage(argv);
                 exit(1);
@@ -170,7 +289,7 @@ int main(int argc, const char **argv) {
         usage(argv);
         exit(1);
     }
-    if (o_opt) {
+    if (o_opt || R_opt) {
         if (source_path == NULL || dest_path == NULL) {
             usage(argv);
             exit(1);
@@ -232,6 +351,8 @@ int main(int argc, const char **argv) {
         ret = copy_offload_status(offload, job_name, max_wait_secs, &status_response);
     } else if (X_opt) {
         ret = copy_offload_shutdown(offload);
+    } else if (R_opt) {
+        ret = test_sticky_methods(offload, source_path, dest_path);
     } else {
         fprintf(stderr, "What action?\n");
         copy_offload_cleanup(offload);


### PR DESCRIPTION
Fix three bugs in libcopyoffload reported in NearNodeFlash/NearNodeFlash.github.io#319:

## 1. Sticky `CURLOPT_CUSTOMREQUEST` corrupts subsequent requests

`copy_offload_cancel()` sets `CURLOPT_CUSTOMREQUEST` to `"DELETE"` and `copy_offload_shutdown()` sets it to `"POST"`, but neither resets it afterward. Since the library reuses a single curl easy handle and `CURLOPT_CUSTOMREQUEST` is sticky, any subsequent `list()`, `status()`, or `hello()` call sends the wrong HTTP method.

**Fix:** Reset `CURLOPT_CUSTOMREQUEST` to `NULL` after `cancel` and `shutdown` calls. Set `CURLOPT_HTTPGET, 1L` in `hello`, `status`, and `list` as a defensive measure.

## 2. `copy_offload_status_cleanup()` leaks memory

`_copy_offload_status_parse()` allocates the response struct with `calloc`, and `copy_offload_status()` passes a `strdup`'d JSON string to it. However, `copy_offload_status_cleanup()` only released the backing json object — it never freed the struct itself, and the `strdup`'d string was never freed.

**Fix:** Free the `calloc`'d struct in `copy_offload_status_cleanup()`. Free the `strdup`'d string in `copy_offload_status()` after parsing.

## 3. `CURLOPT_SSL_VERIFYHOST` set to 1 instead of 2

`1L` only checks that a CN/SAN field exists — it doesn't verify the value matches the hostname. Full hostname verification requires `2L`.

**Fix:** Change from `1L` to `2L`.

## Testing

Added a sticky-method regression test (`-R` flag) to the test tool that exercises multiple operations on a single handle: copy → cancel → list → hello → copy → status → cancel. This verifies HTTP methods are not corrupted across calls. Confirmed the test fails without the fixes and passes with them.